### PR TITLE
Add secure upload endpoint, health route, and documentation

### DIFF
--- a/app/Http/Controllers/UploadController.php
+++ b/app/Http/Controllers/UploadController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class UploadController extends Controller
+{
+    /**
+     * Store an uploaded document in a private disk and return a signed URL.
+     */
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'file' => 'required|file|mimes:pdf,docx,pptx,txt|max:10240',
+        ]);
+
+        $file = $validated['file'];
+
+        // Validate MIME type using finfo
+        $finfo = finfo_open(FILEINFO_MIME_TYPE);
+        $mime = finfo_file($finfo, $file->getRealPath());
+        finfo_close($finfo);
+
+        $allowedMimes = [
+            'application/pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+            'text/plain',
+        ];
+
+        if (! in_array($mime, $allowedMimes, true)) {
+            return response()->json(['message' => 'Invalid file type'], 422);
+        }
+
+        $filename = Str::uuid()->toString().'.'.$file->getClientOriginalExtension();
+        $path = $file->storeAs('', $filename, 'private');
+
+        // Generate temporary download URL valid for 5 minutes
+        $url = Storage::disk('private')->temporaryUrl($path, now()->addMinutes(5));
+
+        return response()->json(['url' => $url, 'path' => $path]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use Illuminate\Cache\RateLimiting\Limit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +22,9 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        RateLimiter::for('ai', function (Request $request) {
+            $userId = optional($request->user())->id;
+            return Limit::perMinute(60)->by($request->ip().'|'.$userId);
+        });
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,8 +7,9 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
-        health: '/up',
+        health: '/healthz',
     )
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->appendToGroup('web', [

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -32,8 +32,17 @@ return [
 
         'local' => [
             'driver' => 'local',
+            'root' => storage_path('app'),
+            'serve' => false,
+            'throw' => false,
+            'report' => false,
+        ],
+
+        'private' => [
+            'driver' => 'local',
             'root' => storage_path('app/private'),
             'serve' => true,
+            'visibility' => 'private',
             'throw' => false,
             'report' => false,
         ],

--- a/docs/env-config.md
+++ b/docs/env-config.md
@@ -1,0 +1,18 @@
+# Environment Configuration
+
+The application reads configuration from the `.env` file. Important keys:
+
+| Key | Description |
+| --- | --- |
+| `APP_URL` | Full URL to the application. Used for links and storage URLs. |
+| `APP_LOCALE` | Default locale (e.g. `en`). |
+| `APP_TIMEZONE` | Time zone identifier. |
+| `DB_*` | Database connection details. |
+| `QUEUE_CONNECTION` | Usually `redis` or `database`. |
+| `CACHE_STORE` | Cache driver, defaults to `file` or `redis`. |
+| `AI_OPENAI_KEY` | API key for OpenAI services. Leave blank to disable. |
+| `FILESYSTEM_DISK` | Default storage disk (`local`, `s3`, etc.). |
+| `MAIL_MAILER` | Mail transport driver (`smtp`, `log`, etc.). |
+| `MAIL_FROM_ADDRESS` | Sender email for notifications. |
+
+After editing `.env`, run `php artisan config:clear` to apply changes.

--- a/docs/install-shared-hosting.md
+++ b/docs/install-shared-hosting.md
@@ -1,0 +1,19 @@
+# Installing on Shared Hosting (cPanel)
+
+1. **Upload files**
+   - Upload the application archive to your hosting account and extract it inside the desired directory.
+2. **Configure PHP**
+   - Ensure PHP 8.2 or higher and required extensions (OpenSSL, PDO, Mbstring, Tokenizer, Fileinfo, JSON, cURL, Zip).
+3. **Create database**
+   - From cPanel, create a MySQL database and user, then assign privileges.
+4. **Set environment values**
+   - Copy `.env.example` to `.env` and update database credentials, `APP_URL`, mail settings, and storage driver.
+5. **Run installer**
+   - Visit your domain and follow the three step installer wizard to generate the app key and run migrations.
+6. **Configure queue & cron**
+   - In cPanel "Cron Jobs", schedule `php artisan schedule:run` every minute.
+   - For queues, use `php artisan queue:work --tries=1` via Supervisor or create another cron job.
+7. **Create storage link**
+   - Run `php artisan storage:link` or ask hosting support to create the symlink from `public/storage` to `storage/app/public`.
+
+After completing these steps the application should be reachable at your domain.

--- a/docs/install-vps.md
+++ b/docs/install-vps.md
@@ -1,0 +1,21 @@
+# Installing on a VPS
+
+1. **Server requirements**
+   - Ubuntu 22.04+, Docker (optional), Git, and PHP 8.2 with common extensions.
+2. **Clone repository**
+   - `git clone <repo> && cd <repo>`
+3. **Environment configuration**
+   - Copy `.env.example` to `.env` and configure database, cache, queue (Redis), mail and `APP_URL`.
+4. **Dependencies**
+   - Run `composer install --optimize-autoloader` and `npm install && npm run build` if serving assets.
+5. **Database migration**
+   - Run `php artisan migrate --seed` to set up tables and seed sample data.
+6. **Queues and scheduler**
+   - Start `php artisan queue:work --daemon` under Supervisor or systemd.
+   - Add cron job: `* * * * * php /path/to/artisan schedule:run >> /dev/null 2>&1`.
+7. **Web server**
+   - Configure Nginx or Apache to point the document root to `public/` and enable HTTPS.
+8. **Docker alternative**
+   - Use `docker compose up -d` to build the containers. Set environment variables in `.env` before running the stack.
+
+The application should now be accessible on the configured domain or IP address.

--- a/docs/license-activation.md
+++ b/docs/license-activation.md
@@ -1,0 +1,10 @@
+# License Activation
+
+1. Purchase the script from CodeCanyon and obtain the purchase code from your downloads page.
+2. After installing the application, visit `/admin/license`.
+3. Enter the purchase code and submit. The server will verify the code with the Envato API.
+4. On success, the license is bound to the current domain and stored hashed in the database.
+5. If verification fails, ensure the server can reach api.envato.com and the code has not been used on another domain.
+6. For development, set `LICENSE_BYPASS=true` in `.env` to skip verification.
+
+A valid license is required for premium features. Unverified installs enter a 7‑day grace period before restrictions apply.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,19 @@
+# Troubleshooting
+
+## Queue not processing
+- Ensure the queue worker is running: `php artisan queue:work`.
+- Check Redis or database connection based on `QUEUE_CONNECTION`.
+
+## Permission errors
+- The web server must be able to write to `storage/` and `bootstrap/cache/`.
+- Run `chmod -R 775 storage bootstrap/cache` and ensure the correct group ownership.
+
+## High memory usage
+- Large PDF or DOCX uploads are parsed asynchronously. Confirm Horizon or queue worker is active.
+- Increase PHP memory limit in `php.ini` if necessary.
+
+## Cannot connect to AI provider
+- Verify API keys in `.env` and that outbound HTTPS traffic is allowed from the server.
+- Check the application logs for detailed error messages.
+
+For additional help, consult the community forum or open a support ticket with your purchase code.

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -1,0 +1,14 @@
+# Upgrading
+
+1. **Backup**
+   - Create a backup of your `.env` file and database before running the updater.
+2. **Upload new files**
+   - Replace the application files with the contents of the new release, excluding the `storage` directory and `vendor` if desired.
+3. **Run updater**
+   - Execute `php artisan app:update` from the project root. The command backs up `.env`, runs new migrations, and clears caches.
+4. **Review changelog**
+   - After updating, consult `CHANGELOG.md` for notable changes and new environment variables.
+5. **Rebuild assets**
+   - If the release contains frontend changes, run `npm install && npm run build`.
+
+Once complete, the application is upgraded to the latest version.

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,6 @@
+<?php
+
+use App\Http\Controllers\UploadController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('throttle:ai')->post('/upload', [UploadController::class, 'store']);

--- a/tests/Feature/UploadTest.php
+++ b/tests/Feature/UploadTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class UploadTest extends TestCase
+{
+    public function test_pdf_upload_is_stored_and_returns_url(): void
+    {
+        Storage::fake('private');
+
+        $file = UploadedFile::fake()->createWithContent('test.pdf', '%PDF-1.4');
+
+        $response = $this->postJson('/api/upload', [
+            'file' => $file,
+        ]);
+
+        $response->assertOk()->assertJsonStructure(['url', 'path']);
+
+        Storage::disk('private')->assertExists($response->json('path'));
+    }
+
+    public function test_invalid_file_type_is_rejected(): void
+    {
+        $file = UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg');
+
+        $response = $this->postJson('/api/upload', [
+            'file' => $file,
+        ]);
+
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
## Summary
- implement signed upload endpoint with MIME checks and private storage
- add API routing with rate limiting and configure health check at `/healthz`
- document installation, configuration, license activation, upgrading, and troubleshooting

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6898be9278ec83288f247b60e552b6be