### PR TITLE
Add AI provider service and integrate with tasks

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -12,51 +12,29 @@ class TaskController extends Controller
     {
         abort_unless($project->tenant_id === $r->user()->tenant_id && $project->user_id === $r->user()->id, 403);
 
-        $task = AiTask::create([
-            'id'         => (string) Str::uuid(),
-            'tenant_id'  => $r->user()->tenant_id,
-            'user_id'    => $r->user()->id,
-            'project_id' => $project->id,
-            'type'       => $type,
-            'status'     => 'succeeded',
-            'message'    => 'Demo output generated.',
-            'input_tokens'  => 500,
-            'output_tokens' => 350,
-            'cost_cents'    => 2, // dummy $0.02
-        ]);
+        $result = app(\App\Services\AiProvider::class)->generate($project, $type, $locale);
 
-        $payload = match ($type) {
-            'summarize' => [
-                'abstract' => 'A concise, 150-word abstract about the uploaded material (demo).',
-                'bullets'  => ['Key point one','Key point two','Key point three','Key point four'],
-                'glossary' => [['term'=>'Example','def'=>'Demo definition']]
-            ],
-            'mindmap' => [
-                'title' => $project->title,
-                'nodes' => [
-                    ['id'=>'n1','text'=>'Main Idea','children'=>[
-                        ['id'=>'n2','text'=>'Branch A'],
-                        ['id'=>'n3','text'=>'Branch B']
-                    ]]
-                ]
-            ],
-            'slides' => [
-                'slides' => [
-                    ['title'=>$project->title, 'bullets'=>['Subtitle / course','Author'], 'notes'=>'Welcome slide'],
-                    ['title'=>'Overview','bullets'=>['Objective','Scope','Method'], 'notes'=>'Keep it brief']
-                ]
-            ],
-            default => []
-        };
+        $task = AiTask::create([
+            'id'            => (string) Str::uuid(),
+            'tenant_id'     => $r->user()->tenant_id,
+            'user_id'       => $r->user()->id,
+            'project_id'    => $project->id,
+            'type'          => $type,
+            'status'        => 'succeeded',
+            'message'       => 'Generated via provider.',
+            'input_tokens'  => $result['input_tokens'] ?? 0,
+            'output_tokens' => $result['output_tokens'] ?? 0,
+            'cost_cents'    => $result['cost_cents'] ?? 0,
+        ]);
 
         AiTaskVersion::create([
             'id'      => (string) Str::uuid(),
             'task_id' => $task->id,
             'locale'  => $locale,
-            'payload' => json_encode($payload),
+            'payload' => $result['raw'] ?? [],
         ]);
 
-        return back()->with('ok', ucfirst($type).' generated (demo).');
+        return back()->with('ok', ucfirst($type).' generated.');
     }
 
     public function summarize(Request $r, AiProject $project) { return $this->makeTask($r, $project, 'summarize', $r->input('locale','en')); }

--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\AiProject;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+class AiProvider
+{
+    protected string $provider;
+    protected string $model;
+
+    private const OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+    private const ANTHROPIC_ENDPOINT = 'https://api.anthropic.com/v1/messages';
+
+    private const OPENAI_PRICING = [
+        'gpt-4o-mini' => ['input' => 0.15 / 1_000_000, 'output' => 0.60 / 1_000_000],
+    ];
+
+    private const ANTHROPIC_PRICING = [
+        'claude-3-haiku-20240307' => ['input' => 0.25 / 1_000_000, 'output' => 1.25 / 1_000_000],
+    ];
+
+    public function __construct()
+    {
+        $this->provider = env('AI_PROVIDER', 'openai');
+        $this->model = env('AI_MODEL', $this->provider === 'anthropic' ? 'claude-3-haiku-20240307' : 'gpt-4o-mini');
+    }
+
+    public function generate(AiProject $project, string $type, string $locale = 'en'): array
+    {
+        $text = '';
+        if ($project->source_disk && $project->source_path) {
+            $text = (string) Storage::disk($project->source_disk)->get($project->source_path);
+        }
+
+        $prompt = "Using locale {$locale}, generate a {$type} in JSON for the following text:\n\n{$text}";
+
+        if ($this->provider === 'anthropic' && !env('ANTHROPIC_API_KEY')) {
+            return ['raw' => ['error' => 'missing anthropic api key'], 'input_tokens' => 0, 'output_tokens' => 0, 'cost_cents' => 0];
+        }
+
+        if ($this->provider === 'openai' && !env('OPENAI_API_KEY')) {
+            return ['raw' => ['error' => 'missing openai api key'], 'input_tokens' => 0, 'output_tokens' => 0, 'cost_cents' => 0];
+        }
+
+        if ($this->provider === 'anthropic') {
+            $response = Http::withHeaders([
+                'x-api-key' => env('ANTHROPIC_API_KEY'),
+                'anthropic-version' => '2023-06-01',
+            ])->post(self::ANTHROPIC_ENDPOINT, [
+                'model' => $this->model,
+                'max_tokens' => 1024,
+                'messages' => [
+                    ['role' => 'user', 'content' => $prompt],
+                ],
+            ]);
+        } else {
+            $response = Http::withToken(env('OPENAI_API_KEY'))
+                ->post(self::OPENAI_ENDPOINT, [
+                    'model' => $this->model,
+                    'response_format' => ['type' => 'json_object'],
+                    'messages' => [
+                        ['role' => 'user', 'content' => $prompt],
+                    ],
+                ]);
+        }
+
+        $data = $response->json();
+        $usage = $data['usage'] ?? [];
+
+        $input = $usage['prompt_tokens'] ?? ($usage['input_tokens'] ?? 0);
+        $output = $usage['completion_tokens'] ?? ($usage['output_tokens'] ?? 0);
+        $cost_cents = $this->calculateCost($this->model, $input, $output);
+
+        return [
+            'raw' => $data,
+            'input_tokens' => $input,
+            'output_tokens' => $output,
+            'cost_cents' => $cost_cents,
+        ];
+    }
+
+    private function calculateCost(string $model, int $input, int $output): int
+    {
+        $pricing = $this->provider === 'anthropic'
+            ? (self::ANTHROPIC_PRICING[$model] ?? null)
+            : (self::OPENAI_PRICING[$model] ?? null);
+
+        if (!$pricing) {
+            return 0;
+        }
+
+        $dollars = $input * $pricing['input'] + $output * $pricing['output'];
+
+        return (int) round($dollars * 100);
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -35,4 +35,14 @@ return [
         ],
     ],
 
+    'openai' => [
+        'key'   => env('OPENAI_API_KEY'),
+        'model' => env('OPENAI_MODEL', 'gpt-4o-mini'),
+    ],
+
+    'anthropic' => [
+        'key'   => env('ANTHROPIC_API_KEY'),
+        'model' => env('ANTHROPIC_MODEL', 'claude-3-haiku-20240307'),
+    ],
+
 ];


### PR DESCRIPTION
## Summary
- add provider service for calling OpenAI or Anthropic and calculating token usage and cost
- wire TaskController to use provider and store full response
- configure OpenAI and Anthropic credentials in services config

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Database file ... does not exist; 24 errors, 4 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6898e481f5dc8328b7dc40ce4568ccba