### PR TITLE
Queue AI task processing

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -4,7 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
-use App\Models\{AiProject, AiTask, AiTaskVersion};
+use App\Jobs\ProcessAiTask;
+use App\Models\{AiProject, AiTask};
 
 class TaskController extends Controller
 {
@@ -12,29 +13,22 @@ class TaskController extends Controller
     {
         abort_unless($project->tenant_id === $r->user()->tenant_id && $project->user_id === $r->user()->id, 403);
 
-        $result = app(\App\Services\AiProvider::class)->generate($project, $type, $locale);
-
         $task = AiTask::create([
             'id'            => (string) Str::uuid(),
             'tenant_id'     => $r->user()->tenant_id,
             'user_id'       => $r->user()->id,
             'project_id'    => $project->id,
             'type'          => $type,
-            'status'        => 'succeeded',
-            'message'       => 'Generated via provider.',
-            'input_tokens'  => $result['input_tokens'] ?? 0,
-            'output_tokens' => $result['output_tokens'] ?? 0,
-            'cost_cents'    => $result['cost_cents'] ?? 0,
+            'status'        => 'queued',
+            'message'       => 'Queued for processing.',
+            'input_tokens'  => 0,
+            'output_tokens' => 0,
+            'cost_cents'    => 0,
         ]);
 
-        AiTaskVersion::create([
-            'id'      => (string) Str::uuid(),
-            'task_id' => $task->id,
-            'locale'  => $locale,
-            'payload' => $result['raw'] ?? [],
-        ]);
+        ProcessAiTask::dispatch($task, $locale);
 
-        return back()->with('ok', ucfirst($type).' generated.');
+        return back()->with('ok', ucfirst($type).' queued.');
     }
 
     public function summarize(Request $r, AiProject $project) { return $this->makeTask($r, $project, 'summarize', $r->input('locale','en')); }

--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\AiTask;
+use App\Models\AiTaskVersion;
+use App\Services\AiProvider;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Str;
+use Throwable;
+
+class ProcessAiTask implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $backoff = 10;
+
+    public function __construct(public AiTask $task, public string $locale)
+    {
+    }
+
+    public function handle(AiProvider $provider): void
+    {
+        $project = $this->task->project;
+        $result = $provider->generate($project, $this->task->type, $this->locale);
+
+        $this->task->update([
+            'status'        => 'succeeded',
+            'message'       => 'Generated via provider.',
+            'input_tokens'  => $result['input_tokens'] ?? 0,
+            'output_tokens' => $result['output_tokens'] ?? 0,
+            'cost_cents'    => $result['cost_cents'] ?? 0,
+        ]);
+
+        AiTaskVersion::create([
+            'id'      => (string) Str::uuid(),
+            'task_id' => $this->task->id,
+            'locale'  => $this->locale,
+            'payload' => $result['raw'] ?? [],
+        ]);
+    }
+
+    public function failed(Throwable $e): void
+    {
+        $this->task->update([
+            'status'  => 'failed',
+            'message' => $e->getMessage(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add ProcessAiTask job to handle provider calls and token accounting with retry and failure hooks
- dispatch AI task job from TaskController so requests return immediately

## Testing
- `./vendor/bin/phpunit --filter test_reset_password_screen_can_be_rendered` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6898e8e95dcc8328bd2c15197b7e7014