### PR TITLE
feat: add token-aware text chunking utility

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -5,12 +5,14 @@ namespace App\Jobs;
 use App\Models\AiTask;
 use App\Models\AiTaskVersion;
 use App\Services\AiProvider;
+use App\Support\TextChunker;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
 use Throwable;
 
 class ProcessAiTask implements ShouldQueue
@@ -27,21 +29,44 @@ class ProcessAiTask implements ShouldQueue
     public function handle(AiProvider $provider): void
     {
         $project = $this->task->project;
-        $result = $provider->generate($project, $this->task->type, $this->locale);
+        $text = $project->source_text ?? '';
+        if (!$text && $project->source_disk && $project->source_path) {
+            $text = (string) Storage::disk($project->source_disk)->get($project->source_path);
+        }
+
+        $chunks = TextChunker::chunk($text);
+        if (empty($chunks)) {
+            $chunks = [''];
+        }
+
+        $payload = [];
+        $inputTokens = $outputTokens = $costCents = 0;
+
+        foreach ($chunks as $index => $chunk) {
+            $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
+            $payload[] = [
+                'index' => $index,
+                'chunk' => $chunk,
+                'raw'   => $result['raw'] ?? [],
+            ];
+            $inputTokens += $result['input_tokens'] ?? 0;
+            $outputTokens += $result['output_tokens'] ?? 0;
+            $costCents += $result['cost_cents'] ?? 0;
+        }
 
         $this->task->update([
             'status'        => 'succeeded',
             'message'       => 'Generated via provider.',
-            'input_tokens'  => $result['input_tokens'] ?? 0,
-            'output_tokens' => $result['output_tokens'] ?? 0,
-            'cost_cents'    => $result['cost_cents'] ?? 0,
+            'input_tokens'  => $inputTokens,
+            'output_tokens' => $outputTokens,
+            'cost_cents'    => $costCents,
         ]);
 
         AiTaskVersion::create([
             'id'      => (string) Str::uuid(),
             'task_id' => $this->task->id,
             'locale'  => $this->locale,
-            'payload' => $result['raw'] ?? [],
+            'payload' => $payload,
         ]);
     }
 

--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -28,9 +28,9 @@ class AiProvider
         $this->model = env('AI_MODEL', $this->provider === 'anthropic' ? 'claude-3-haiku-20240307' : 'gpt-4o-mini');
     }
 
-    public function generate(AiProject $project, string $type, string $locale = 'en'): array
+    public function generate(AiProject $project, string $type, string $locale = 'en', ?string $text = null): array
     {
-        $text = $project->source_text ?? '';
+        $text = $text ?? ($project->source_text ?? '');
         if (!$text && $project->source_disk && $project->source_path) {
             $text = (string) Storage::disk($project->source_disk)->get($project->source_path);
         }

--- a/app/Support/TextChunker.php
+++ b/app/Support/TextChunker.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Support;
+
+class TextChunker
+{
+    /**
+     * Clean the given text by removing control characters
+     * and normalizing whitespace.
+     */
+    public static function clean(string $text): string
+    {
+        $text = preg_replace('/[[:cntrl:]]+/u', ' ', $text);
+        $text = preg_replace('/\s+/u', ' ', $text);
+        return trim($text);
+    }
+
+    /**
+     * Split text into chunks by token count. Tokens are approximated
+     * by splitting on whitespace.
+     *
+     * @return array<int,string>
+     */
+    public static function chunk(string $text, int $maxTokens = 800): array
+    {
+        $clean = self::clean($text);
+        if ($clean === '') {
+            return [];
+        }
+
+        $tokens = preg_split('/\s+/u', $clean, -1, PREG_SPLIT_NO_EMPTY);
+        $chunks = [];
+        $current = [];
+
+        foreach ($tokens as $token) {
+            $current[] = $token;
+            if (count($current) >= $maxTokens) {
+                $chunks[] = implode(' ', $current);
+                $current = [];
+            }
+        }
+
+        if ($current) {
+            $chunks[] = implode(' ', $current);
+        }
+
+        return $chunks;
+    }
+}

--- a/tests/Unit/TextChunkerTest.php
+++ b/tests/Unit/TextChunkerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\TextChunker;
+use PHPUnit\Framework\TestCase;
+
+class TextChunkerTest extends TestCase
+{
+    public function test_clean_removes_control_chars_and_normalizes_whitespace(): void
+    {
+        $input = "Hello\tWorld\n" . chr(0) . "Example";
+        $expected = 'Hello World Example';
+        $this->assertSame($expected, TextChunker::clean($input));
+    }
+
+    public function test_chunk_splits_text_by_token_count(): void
+    {
+        $text = 'one two three four five';
+        $chunks = TextChunker::chunk($text, 2);
+        $this->assertSame(['one two', 'three four', 'five'], $chunks);
+    }
+}


### PR DESCRIPTION
## Summary
- add TextChunker helper to clean and split text into token-aware chunks
- chunk task source text and aggregate provider calls
- cover TextChunker with unit tests

## Testing
- `./vendor/bin/phpunit tests/Unit/TextChunkerTest.php`
- `./vendor/bin/phpunit` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6898eb844f3483289b308bd7f5936070