### PR TITLE
feat: enforce tenant scope

### DIFF
--- a/app/Models/AiProject.php
+++ b/app/Models/AiProject.php
@@ -1,6 +1,45 @@
 <?php
+
 namespace App\Models;
+
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
-class AiProject extends Model { use HasUuids; protected $fillable=['tenant_id','user_id','title','source_filename','source_disk','source_path','source_text','language','status','error_message']; public function tenant(){return $this->belongsTo(Tenant::class);} public function user(){return $this->belongsTo(User::class);} public function tasks(){return $this->hasMany(AiTask::class,'project_id');}}
+class AiProject extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'title',
+        'source_filename',
+        'source_disk',
+        'source_path',
+        'source_text',
+        'language',
+        'status',
+        'error_message',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function tasks()
+    {
+        return $this->hasMany(AiTask::class, 'project_id');
+    }
+}

--- a/app/Models/AiTask.php
+++ b/app/Models/AiTask.php
@@ -1,6 +1,39 @@
 <?php
+
 namespace App\Models;
+
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
-class AiTask extends Model { use HasUuids; protected $fillable=['tenant_id','user_id','project_id','type','input_tokens','output_tokens','cost_cents','status','message']; public function project(){return $this->belongsTo(AiProject::class,'project_id');} public function versions(){return $this->hasMany(AiTaskVersion::class,'task_id');} }
+class AiTask extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'project_id',
+        'type',
+        'input_tokens',
+        'output_tokens',
+        'cost_cents',
+        'status',
+        'message',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    public function project()
+    {
+        return $this->belongsTo(AiProject::class, 'project_id');
+    }
+
+    public function versions()
+    {
+        return $this->hasMany(AiTaskVersion::class, 'task_id');
+    }
+}

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -1,6 +1,36 @@
 <?php
+
 namespace App\Models;
+
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
-class License extends Model { use HasUuids; protected $fillable=['tenant_id','purchase_code','domain','activated_at','status','meta']; protected $casts=['meta'=>'array','activated_at'=>'datetime']; public function tenant(){return $this->belongsTo(Tenant::class);} }
+class License extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'purchase_code',
+        'domain',
+        'activated_at',
+        'status',
+        'meta',
+    ];
+
+    protected $casts = [
+        'meta' => 'array',
+        'activated_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Models/Scopes/EnforceTenant.php
+++ b/app/Models/Scopes/EnforceTenant.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class EnforceTenant implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $tenantId = auth()->user()->tenant_id ?? null;
+        if ($tenantId) {
+            $builder->where($model->qualifyColumn('tenant_id'), $tenantId);
+        }
+    }
+}

--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -1,6 +1,38 @@
 <?php
+
 namespace App\Models;
+
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 
-class Subscription extends Model { use HasUuids; protected $fillable=['tenant_id','plan_id','gateway','gateway_sub_id','status','current_period_start','current_period_end','cancel_at_period_end']; public function plan(){return $this->belongsTo(Plan::class);} public function tenant(){return $this->belongsTo(Tenant::class);} }
+class Subscription extends Model
+{
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'plan_id',
+        'gateway',
+        'gateway_sub_id',
+        'status',
+        'current_period_start',
+        'current_period_end',
+        'cancel_at_period_end',
+    ];
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    public function plan()
+    {
+        return $this->belongsTo(Plan::class);
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+}

--- a/app/Models/UsageLog.php
+++ b/app/Models/UsageLog.php
@@ -2,8 +2,9 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
 
 class UsageLog extends Model
 {
@@ -34,6 +35,18 @@ class UsageLog extends Model
         'created_at' => 'datetime',
     ];
 
-    public function tenant() { return $this->belongsTo(Tenant::class); }
-    public function user()   { return $this->belongsTo(User::class); }
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    public function tenant()
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\EnforceTenant;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -16,7 +17,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'role',         // admin, user, etc.
+        'role',         // admin, user, dll.
         'usage_tokens', // total token AI terpakai
         'usage_cost',   // total biaya terpakai
         'plan_id',      // untuk billing
@@ -39,7 +40,12 @@ class User extends Authenticatable
         ];
     }
 
-    /** 
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new EnforceTenant);
+    }
+
+    /**
      * Relasi ke tenant
      */
     public function tenant()
@@ -47,7 +53,7 @@ class User extends Authenticatable
         return $this->belongsTo(Tenant::class);
     }
 
-    /** 
+    /**
      * Relasi ke plan
      */
     public function plan()
@@ -55,7 +61,7 @@ class User extends Authenticatable
         return $this->belongsTo(Plan::class);
     }
 
-    /** 
+    /**
      * Cek apakah user ini admin tenant
      */
     public function isTenantAdmin(): bool


### PR DESCRIPTION
## Summary
- add EnforceTenant global scope to restrict queries by authenticated tenant
- apply scope to tenant-aware models (projects, tasks, usage logs, subscriptions, licenses, users)

## Testing
- `php artisan test` *(fails: Database file at path /workspace/aiassisten/database/database.sqlite does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6898f077b51c8328b601e4ca986fe871