### PR TITLE
Add locale preference route and RTL handling

### DIFF
--- a/app/Http/Controllers/LocaleController.php
+++ b/app/Http/Controllers/LocaleController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cookie;
+
+class LocaleController extends Controller
+{
+    public function update(Request $request): RedirectResponse
+    {
+        $available = config('app.available_locales', []);
+        $locale = $request->input('locale');
+
+        if (! in_array($locale, $available)) {
+            $locale = config('app.locale');
+        }
+
+        if ($user = Auth::user()) {
+            $user->locale = $locale;
+            $user->save();
+        }
+
+        Cookie::queue('locale', $locale, 60 * 24 * 365);
+
+        return back();
+    }
+}
+

--- a/app/Http/Middleware/ApplyRTL.php
+++ b/app/Http/Middleware/ApplyRTL.php
@@ -10,7 +10,7 @@ class ApplyRTL
 {
     public function handle(Request $request, Closure $next)
     {
-        $isRtl = in_array(app()->getLocale(), ['ar']);
+        $isRtl = in_array(app()->getLocale(), config('app.rtl_locales', []));
         View::share('isRtl', $isRtl);
         return $next($request);
     }

--- a/app/Http/Middleware/ResolveLocale.php
+++ b/app/Http/Middleware/ResolveLocale.php
@@ -6,25 +6,28 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Cookie;
 
 class ResolveLocale
 {
     public function handle(Request $request, Closure $next)
     {
-        $locale = $request->route('locale');
         $available = config('app.available_locales', []);
+        $locale = null;
 
-        if (! $locale && $request->query('locale')) {
-            $locale = $request->query('locale');
-        }
-
-        if (! $locale && ($user = Auth::user()) && $user->locale) {
+        if (($user = Auth::user()) && $user->locale) {
             $locale = $user->locale;
         }
 
         if (! $locale && $request->cookie('locale')) {
             $locale = $request->cookie('locale');
+        }
+
+        if (! $locale && $request->route('locale')) {
+            $locale = $request->route('locale');
+        }
+
+        if (! $locale && $request->query('locale')) {
+            $locale = $request->query('locale');
         }
 
         if (! $locale) {
@@ -36,7 +39,6 @@ class ResolveLocale
         }
 
         App::setLocale($locale);
-        Cookie::queue('locale', $locale, 60 * 24 * 365);
 
         return $next($request);
     }

--- a/config/app.php
+++ b/config/app.php
@@ -86,6 +86,8 @@ return [
         'en','es','pt-BR','id','th','ar','fr','de','tr','vi','hi','ja'
     ],
 
+    'rtl_locales' => ['ar'],
+
     'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
 
     /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,15 @@
 <?php
 
 use App\Http\Controllers\BillingController;
+use App\Http\Controllers\LocaleController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\TaskController;
 use App\Http\Controllers\WebhookController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', fn () => view('welcome'))->name('landing');
+
+Route::post('/locale', [LocaleController::class, 'update'])->name('locale');
 
 Route::middleware(['auth'])->group(function () {
     Route::get('/dashboard', [ProjectController::class, 'index'])->name('dashboard');


### PR DESCRIPTION
## Summary
- add LocaleController to persist preferred language and cookie
- register POST /locale route
- resolve locale from saved preference and expose RTL locales via config

## Testing
- `./vendor/bin/phpunit` *(fails: Tests: 33, Assertions: 34, Errors: 4, Failures: 23)*

------
https://chatgpt.com/codex/tasks/task_e_6898f507a2348328961074707283bc33