### PR TITLE
Add installer command and setup docs

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Models\License;
+
+class InstallCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     */
+    protected $signature = 'aiassisten:install';
+
+    /**
+     * The console command description.
+     */
+    protected $description = 'Interactive installer to bootstrap tenant, admin, and license information';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        if (Tenant::exists()) {
+            $this->info('Installation already completed.');
+            return self::SUCCESS;
+        }
+
+        $this->info('Starting AiAssisten installation...');
+
+        $tenantName = $this->ask('Tenant name');
+        $tenant = Tenant::create([
+            'name' => $tenantName,
+            'slug' => Str::slug($tenantName),
+        ]);
+
+        $adminName = $this->ask('Admin name');
+        $adminEmail = $this->ask('Admin email');
+        $adminPassword = $this->secret('Admin password');
+        User::create([
+            'tenant_id' => $tenant->id,
+            'name' => $adminName,
+            'email' => $adminEmail,
+            'password' => Hash::make($adminPassword),
+            'role' => 'admin',
+        ]);
+
+        $purchaseCode = $this->ask('Purchase code');
+        $defaultDomain = parse_url(config('app.url'), PHP_URL_HOST) ?? config('app.url');
+        $domain = $this->ask('Licensed domain', $defaultDomain);
+        License::create([
+            'tenant_id' => $tenant->id,
+            'purchase_code' => $purchaseCode,
+            'domain' => $domain,
+            'activated_at' => now(),
+            'status' => 'valid',
+        ]);
+
+        $this->info('Installation complete.');
+        return self::SUCCESS;
+    }
+}
+

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,0 +1,18 @@
+# Billing Configuration
+
+The application supports subscriptions through Stripe or PayPal.
+
+## Stripe
+1. Set the following environment variables in `.env`:
+   - `STRIPE_SECRET`
+   - `STRIPE_WEBHOOK_SECRET`
+2. In the Stripe dashboard, create a webhook endpoint pointing to `/webhooks/stripe` and subscribe to subscription events.
+
+## PayPal
+1. Set the following environment variables in `.env`:
+   - `PAYPAL_CLIENT_ID`
+   - `PAYPAL_SECRET`
+   - `PAYPAL_WEBHOOK_ID`
+2. In the PayPal dashboard, create a webhook pointing to `/webhooks/paypal` and enable subscription events.
+
+After configuring the credentials and webhooks, tenants can purchase plans through the billing page.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,22 @@
+# Installation Guide
+
+1. **Clone the repository**
+   - `git clone <repo> && cd <repo>`
+2. **Install dependencies**
+   - `composer install --optimize-autoloader`
+   - `npm install && npm run build` (or `npm run dev` during development)
+3. **Environment setup**
+   - Copy `.env.example` to `.env` and update database, cache, mail, and `APP_URL` settings.
+   - Run `php artisan key:generate` to set the application key.
+4. **Database migration**
+   - Run `php artisan migrate` to create the database tables.
+5. **Interactive installer**
+   - Execute `php artisan aiassisten:install` and follow the prompts to create the first tenant, admin user, and license information.
+6. **Queue worker**
+   - Start a worker with `php artisan queue:work` or use Supervisor/systemd. See [queues.md](queues.md) for detailed instructions.
+7. **Billing configuration**
+   - Configure Stripe or PayPal credentials in `.env` and set up webhooks. See [billing.md](billing.md) for more information.
+8. **Serve the application**
+   - `php artisan serve` (or configure Nginx/Apache pointing to `public/`).
+
+The application should now be accessible on the configured domain.

--- a/docs/queues.md
+++ b/docs/queues.md
@@ -1,6 +1,6 @@
 # Queue Workers
 
-The application offloads long-running work to the queue. `ProcessAiTask` and PPTX export jobs run asynchronously and require a Redis-backed queue.
+The application offloads long-running work to the queue. `ProcessAiTask` and PPTX export jobs run asynchronously and require a Redis-backed queue. After running `php artisan aiassisten:install`, configure and start workers as described below.
 
 ## Redis
 


### PR DESCRIPTION
## Summary
- add `aiassisten:install` artisan command for initial tenant, admin, and license seeding
- document full installation flow, queue workers, and billing setup

## Testing
- `composer install`
- `./vendor/bin/phpunit` (fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist; 4 failures, 25 errors)


------
https://chatgpt.com/codex/tasks/task_e_6898f7d946f883289d8fae6c54048f76