### PR TITLE
Enable dependency injection for dashboard route

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -9,10 +9,10 @@ use App\Services\DocumentParser;
 
 class ProjectController extends Controller
 {
-    public function index(Request $r)
+    public function index(Request $request)
     {
-        $projects = AiProject::where('tenant_id', $r->user()->tenant_id)
-            ->where('user_id', $r->user()->id)
+        $projects = AiProject::where('tenant_id', $request->user()->tenant_id)
+            ->where('user_id', $request->user()->id)
             ->with('tasks.versions')
             ->latest()->paginate(8);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,21 +18,7 @@ Route::post('/locale', [LocaleController::class, 'update'])->name('locale');
 // Authenticated routes
 Route::middleware(['auth'])->group(function () {
 
-    // Dashboard - tambahkan fallback guard
-    Route::get('/dashboard', function () {
-        try {
-            return app(ProjectController::class)->index();
-        } catch (\Throwable $e) {
-            \Log::error('Dashboard error', [
-                'user_id' => auth()->id(),
-                'error'   => $e->getMessage(),
-            ]);
-            // Fallback view supaya nggak blank/500
-            return view('dashboard-fallback', [
-                'message' => 'Terjadi kesalahan saat memuat dashboard.',
-            ]);
-        }
-    })->name('dashboard');
+    Route::get('/dashboard', [ProjectController::class, 'index'])->name('dashboard');
 
     // Projects
     Route::post('/projects', [ProjectController::class, 'store'])->name('projects.store');


### PR DESCRIPTION
## Summary
- Route `/dashboard` now directly maps to `ProjectController::index` for framework-driven dependency injection
- Accept `Illuminate\Http\Request` in `ProjectController::index`

## Testing
- `./vendor/bin/phpunit` *(fails: Database file at path /workspace/aiassisten/database/database.sqlite does not exist; 4 test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6899078551e48328853734a2abd5e55e