### PR TITLE
Add authentication middleware with login redirect

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+
+class Authenticate extends Middleware
+{
+    protected function redirectTo($request): ?string
+    {
+        return $request->expectsJson() ? null : route('login');
+    }
+}


### PR DESCRIPTION
## Summary
- add `Authenticate` middleware extending Laravel's base middleware to redirect unauthenticated users to the login route

## Testing
- `composer dump-autoload`
- `vendor/bin/phpunit` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_689914c87afc83289946c1e1cbcd265a