### PR TITLE
Optimize project index query

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -2,19 +2,28 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 use App\Models\AiProject;
 use App\Services\DocumentParser;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class ProjectController extends Controller
 {
     public function index(Request $request)
     {
-        $projects = AiProject::where('tenant_id', $request->user()->tenant_id)
+        $projects = AiProject::select('id', 'title', 'language', 'status', 'source_filename', 'created_at')
+            ->where('tenant_id', $request->user()->tenant_id)
             ->where('user_id', $request->user()->id)
-            ->with('tasks.versions')
-            ->latest()->paginate(8);
+            ->with([
+                'tasks' => fn ($q) => $q->select('id', 'project_id', 'type', 'status', 'created_at')
+                    ->latest()->limit(1)
+                    ->with([
+                        'versions' => fn ($q) => $q->select('id', 'task_id', 'file_path', 'file_disk', 'created_at')
+                            ->latest()->limit(1),
+                    ]),
+            ])
+            ->latest()
+            ->paginate(8);
 
         return view('dashboard', compact('projects'));
     }
@@ -22,12 +31,15 @@ class ProjectController extends Controller
     public function store(Request $r, DocumentParser $parser)
     {
         $r->validate([
-            'title' => ['required','string','max:160'],
-            'file'  => ['nullable','file','mimes:pdf,txt,doc,docx,ppt,pptx','max:10240'], // 10MB
-            'language' => ['nullable','string','max:10'],
+            'title' => ['required', 'string', 'max:160'],
+            'file' => ['nullable', 'file', 'mimes:pdf,txt,doc,docx,ppt,pptx', 'max:10240'], // 10MB
+            'language' => ['nullable', 'string', 'max:10'],
         ]);
 
-        $path = null; $disk = 'private'; $filename = null; $text = '';
+        $path = null;
+        $disk = 'private';
+        $filename = null;
+        $text = '';
         if ($r->hasFile('file')) {
             $filename = $r->file('file')->getClientOriginalName();
             $path = $r->file('file')->store("uploads/{$r->user()->tenant_id}", $disk);
@@ -35,16 +47,16 @@ class ProjectController extends Controller
         }
 
         AiProject::create([
-            'id'              => (string) Str::uuid(),
-            'tenant_id'       => $r->user()->tenant_id,
-            'user_id'         => $r->user()->id,
-            'title'           => $r->string('title'),
+            'id' => (string) Str::uuid(),
+            'tenant_id' => $r->user()->tenant_id,
+            'user_id' => $r->user()->id,
+            'title' => $r->string('title'),
             'source_filename' => $filename,
-            'source_disk'     => $disk,
-            'source_path'     => $path,
-            'language'        => $r->input('language', $r->user()->locale ?? 'en'),
-            'source_text'     => $text,
-            'status'          => 'ready',
+            'source_disk' => $disk,
+            'source_path' => $path,
+            'language' => $r->input('language', $r->user()->locale ?? 'en'),
+            'source_text' => $text,
+            'status' => 'ready',
         ]);
 
         return back()->with('ok', 'Project created.');
@@ -54,6 +66,7 @@ class ProjectController extends Controller
     {
         abort_unless($project->tenant_id === $r->user()->tenant_id && $project->user_id === $r->user()->id, 403);
         $project->delete();
+
         return back()->with('ok', 'Project deleted.');
     }
 }


### PR DESCRIPTION
## Summary
- Avoid loading heavy source_text by selecting only required project columns
- Limit eager loaded tasks and versions to latest entries with selective columns

## Testing
- `php artisan test` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68991b5cb1b08328b1ee48e5fc1428a9