### PR TITLE
Guard tenant scope by checking auth user

### DIFF
--- a/app/Models/Scopes/EnforceTenant.php
+++ b/app/Models/Scopes/EnforceTenant.php
@@ -10,9 +10,11 @@ class EnforceTenant implements Scope
 {
     public function apply(Builder $builder, Model $model): void
     {
-        $tenantId = auth()->user()->tenant_id ?? null;
-        if ($tenantId) {
-            $builder->where($model->qualifyColumn('tenant_id'), $tenantId);
+        if (auth()->hasUser()) {
+            $tenantId = auth()->user()?->tenant_id;
+            if ($tenantId) {
+                $builder->where($model->qualifyColumn('tenant_id'), $tenantId);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Avoid recursive auth calls in `EnforceTenant` scope by checking `auth()->hasUser()` and using null-safe tenant access

## Testing
- `vendor/bin/phpunit` *(fails: UploadTest returned 404 responses; 25 errors, 4 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68991dec9e9c832897a3d52114446f6b