### PR TITLE
Move HTTP Kernel to proper namespace

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,3 +1,9 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
 class Kernel extends HttpKernel
 {
     /**


### PR DESCRIPTION
## Summary
- move `Kernel` from `app/Http/Middleware` to `app/Http`
- add namespace and HttpKernel import in `Kernel`
- ensure route middleware aliases for tenant, license, cost cap, and admin

## Testing
- `composer dump-autoload`
- `CACHE_STORE=file php artisan optimize:clear`
- `php artisan test` *(fails: No application encryption key has been specified and missing routes)*

------
https://chatgpt.com/codex/tasks/task_e_68992179f3f083288a05698f69ad06d7