### PR TITLE
Rename routeMiddleware property to middlewareAliases

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -7,11 +7,11 @@ use Illuminate\Foundation\Http\Kernel as HttpKernel;
 class Kernel extends HttpKernel
 {
     /**
-     * The application's route middleware.
+     * The application's middleware aliases.
      *
      * @var array<string, class-string|string>
      */
-    protected $routeMiddleware = [
+    protected $middlewareAliases = [
         // middleware bawaan Laravel
         'auth' => \App\Http\Middleware\Authenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,


### PR DESCRIPTION
## Summary
- rename Kernel's routeMiddleware property to middlewareAliases

## Testing
- `php artisan test` *(fails: Database file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68992499686483289e11bb9107a82516