### PR TITLE
Allow GET method for mindmap task

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -34,7 +34,16 @@ class TaskController extends Controller
     }
 
     public function summarize(Request $r, AiProject $project) { return $this->makeTask($r, $project, 'summarize', $r->input('locale','en')); }
-    public function mindmap(Request $r, AiProject $project)   { return $this->makeTask($r, $project, 'mindmap',   $r->input('locale','en')); }
+    public function mindmap(Request $r, AiProject $project)
+    {
+        abort_unless($project->tenant_id === $r->user()->tenant_id && $project->user_id === $r->user()->id, 403);
+
+        if ($r->isMethod('get')) {
+            return view('tasks.mindmap', ['project' => $project]);
+        }
+
+        return $this->makeTask($r, $project, 'mindmap', $r->input('locale', 'en'));
+    }
     public function slides(Request $r, AiProject $project)    { return $this->makeTask($r, $project, 'slides',    $r->input('locale','en')); }
 
     public function download(Request $r, AiTaskVersion $version, PptxExporter $exporter)

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,12 @@
+# Task Endpoints
+
+The application queues AI tasks such as summaries, mindmaps, and slides for a project.
+
+## Mindmap
+
+`/projects/{project}/tasks/mindmap`
+
+Accepts **GET** and **POST** requests.
+
+- **GET**: Displays a page describing the endpoint.
+- **POST**: Queues a mindmap generation task for the project. Include the CSRF token when submitting the form.

--- a/resources/views/tasks/mindmap.blade.php
+++ b/resources/views/tasks/mindmap.blade.php
@@ -1,0 +1,13 @@
+@extends('layouts.app')
+
+@section('title', 'Mindmap Task')
+
+@section('header')
+  <h2 class="font-semibold text-xl text-gray-800">Mindmap</h2>
+@endsection
+
+@section('content')
+  <div class="max-w-7xl mx-auto px-6 py-8">
+    <p>Send a POST request to this endpoint to queue a mindmap task for this project.</p>
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,7 @@ Route::middleware(['auth'])->group(function () {
     // Tasks (throttled + cost cap)
     Route::middleware(['throttle:tasks', 'cost.cap'])->group(function () {
         Route::post('/projects/{project}/tasks/summarize', [TaskController::class, 'summarize'])->name('tasks.summarize');
-        Route::post('/projects/{project}/tasks/mindmap', [TaskController::class, 'mindmap'])->name('tasks.mindmap');
+        Route::match(['get', 'post'], '/projects/{project}/tasks/mindmap', [TaskController::class, 'mindmap'])->name('tasks.mindmap');
         Route::post('/projects/{project}/tasks/slides', [TaskController::class, 'slides'])->name('tasks.slides');
     });
 


### PR DESCRIPTION
## Summary
- allow GET requests for the mindmap task route
- handle GET requests in `TaskController::mindmap` and show guidance view
- document task endpoint methods

## Testing
- `php artisan test` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68992471ccd083288d065dd126c11268