### PR TITLE
Add task status endpoint

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -33,6 +33,25 @@ class TaskController extends Controller
         return back()->with('ok', ucfirst($type).' queued.');
     }
 
+    public function show(Request $r, AiTask $task)
+    {
+        $project = $r->route('project');
+
+        abort_unless(
+            $project &&
+            $project->tenant_id === $r->user()->tenant_id &&
+            $project->user_id === $r->user()->id &&
+            $task->project_id === $project->id,
+            403
+        );
+
+        return [
+            'status'   => $task->status,
+            'message'  => $task->message,
+            'versions' => $task->versions()->latest()->get(),
+        ];
+    }
+
     public function summarize(Request $r, AiProject $project) { return $this->makeTask($r, $project, 'summarize', $r->input('locale','en')); }
     public function mindmap(Request $r, AiProject $project)
     {

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,8 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/projects/{project}/tasks/slides', [TaskController::class, 'slides'])->name('tasks.slides');
     });
 
+    Route::get('/projects/{project}/tasks/{task}', [TaskController::class, 'show'])->name('tasks.show');
+
     // Versions
     Route::get('/versions/{version}/download', [TaskController::class, 'download'])->name('versions.download');
 


### PR DESCRIPTION
## Summary
- add TaskController@show to verify ownership and return task status, message and latest versions
- expose GET /projects/{project}/tasks/{task} route for retrieving task info

## Testing
- `./vendor/bin/phpunit` *(fails: Errors 25, Failures 4)*

------
https://chatgpt.com/codex/tasks/task_e_68992d30ae608328a4ebb6eb707bcbbf