### PR TITLE
Handle running status for AI tasks

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -29,6 +29,11 @@ class ProcessAiTask implements ShouldQueue
 
     public function handle(AiProvider $provider): void
     {
+        $this->task->update([
+            'status'  => 'running',
+            'message' => 'Processing...',
+        ]);
+
         $project = $this->task->project;
         $text = $project->source_text ?? '';
         if (!$text && $project->source_disk && $project->source_path) {

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -110,6 +110,7 @@
             @php
               $statusColor = match($p->status) {
                 'queued' => 'bg-amber-100 text-amber-800',
+                'running' => 'bg-blue-100 text-blue-800',
                 'ready' => 'bg-emerald-100 text-emerald-800',
                 'failed' => 'bg-rose-100 text-rose-800',
                 default => 'bg-gray-100 text-gray-800'


### PR DESCRIPTION
## Summary
- Track running tasks by updating status and message when processing begins
- Display new `running` status on dashboard with blue pill styling

## Testing
- `vendor/bin/phpunit` *(fails: Database file at path [database/database.sqlite] does not exist; 33 tests, 25 errors, 4 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68992cad7b008328b3d769e5b54fdbac