### PR TITLE
Display task results after completion

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -48,7 +48,7 @@ class TaskController extends Controller
         return [
             'status'   => $task->status,
             'message'  => $task->message,
-            'versions' => $task->versions()->latest()->get(),
+            'versions' => $task->versions()->latest()->get()->makeVisible('payload'),
         ];
     }
 

--- a/resources/views/components/task-result.blade.php
+++ b/resources/views/components/task-result.blade.php
@@ -1,0 +1,45 @@
+@props(['project', 'task'])
+
+<div x-data="{
+    url: '{{ route('tasks.show', [$project, $task]) }}',
+    status: null,
+    version: null,
+    result: {},
+    // Poll until task finishes. Consider caching trimmed payload for faster access.
+    poll() {
+        fetch(this.url)
+            .then(r => r.json())
+            .then(d => {
+                this.status = d.status;
+                if (d.status === 'succeeded' && d.versions.length > 0) {
+                    this.version = d.versions[0];
+                    let raw = this.version.payload?.[0]?.raw;
+                    let content = raw?.choices?.[0]?.message?.content || raw?.content?.[0]?.text || '';
+                    try {
+                        this.result = JSON.parse(content);
+                    } catch (e) {
+                        this.result = { summary: content };
+                    }
+                } else if (d.status !== 'failed') {
+                    setTimeout(() => this.poll(), 2000);
+                }
+            });
+    }
+}" x-init="poll" class="space-y-2">
+    <template x-if="status === 'succeeded' && result.summary">
+        <pre class="whitespace-pre-wrap text-sm bg-gray-50 p-2 rounded" x-text="result.summary"></pre>
+    </template>
+    <template x-if="status === 'succeeded' && result.mindmap">
+        <ul class="list-disc ml-5 text-sm">
+            <template x-for="(item, i) in result.mindmap" :key="i">
+                <li x-text="item"></li>
+            </template>
+        </ul>
+    </template>
+    <template x-if="status === 'succeeded' && version && version.file_path">
+        <a :href="'/versions/' + version.id + '/download'" class="text-sm text-violet-600 underline">Download slides</a>
+    </template>
+    <template x-if="status && status !== 'succeeded'">
+        <div class="text-sm text-gray-500" x-text="status + '...'" />
+    </template>
+</div>

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -115,10 +115,13 @@
                 'failed' => 'bg-rose-100 text-rose-800',
                 default => 'bg-gray-100 text-gray-800'
               };
+              $summaryTask = $p->tasks->where('type','summarize')->sortByDesc('created_at')->first();
+              $mindmapTask = $p->tasks->where('type','mindmap')->sortByDesc('created_at')->first();
               $slidesTask = $p->tasks->where('type','slides')->sortByDesc('created_at')->first();
               $slidesVersion = $slidesTask?->versions->sortByDesc('created_at')->first();
             @endphp
-            <div class="flex flex-col md:flex-row md:items-center justify-between rounded-xl border p-4 hover:bg-gray-50 transition">
+            <div class="rounded-xl border p-4 hover:bg-gray-50 transition flex flex-col">
+              <div class="flex flex-col md:flex-row md:items-center justify-between">
               <div class="space-y-1">
                 <div class="font-medium text-gray-900">{{ $p->title }}</div>
                 <div class="text-sm text-gray-500">
@@ -146,6 +149,18 @@
                   @csrf @method('DELETE')
                   <button class="px-3 py-2 rounded-lg border text-rose-600 hover:bg-rose-50">Delete</button>
                 </form>
+              </div>
+              </div>
+              <div class="mt-4 space-y-2">
+                @if($summaryTask)
+                  <x-task-result :project="$p" :task="$summaryTask" />
+                @endif
+                @if($mindmapTask)
+                  <x-task-result :project="$p" :task="$mindmapTask" />
+                @endif
+                @if($slidesTask)
+                  <x-task-result :project="$p" :task="$slidesTask" />
+                @endif
               </div>
             </div>
           @endforeach


### PR DESCRIPTION
## Summary
- Expose task payloads in the task detail endpoint so clients can read generated content
- Add a polling Blade component to render summaries, mindmaps, or slide downloads once a task succeeds
- Show latest task results on the dashboard using the new component

## Testing
- `./vendor/bin/phpunit` *(fails: Database file at path /workspace/aiassisten/database/database.sqlite does not exist; several expected status codes returned 404)*

------
https://chatgpt.com/codex/tasks/task_e_68992ed10e0c832884ce0390f22f4c8c