### PR TITLE
Use API download URL for task result link

### DIFF
--- a/resources/views/components/task-result.blade.php
+++ b/resources/views/components/task-result.blade.php
@@ -14,8 +14,8 @@
             .then(d => {
                 this.status = d.status;
                 this.message = d.message;
-                this.downloadUrl = d.download_url;
                 if (d.status === 'done') {
+                    this.downloadUrl = d.download_url;
                     if (d.versions.length > 0) {
                         this.version = d.versions[0];
                         let content = this.version.payload?.content || '';


### PR DESCRIPTION
## Summary
- load download_url from task API when polling
- link task results to API-provided download URL

## Testing
- `composer install`
- `vendor/bin/phpunit` (fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist. Ensure this is an absolute path to the database.)

------
https://chatgpt.com/codex/tasks/task_e_6899d593e940832898460885b118ed87