### PR TITLE
Add task version preview endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ We would like to extend our thanks to the following sponsors for funding Laravel
 - **[byte5](https://byte5.de)**
 - **[OP.GG](https://op.gg)**
 
+## Task Results
+
+Task outputs are stored as versions. Each version may be previewed at `/versions/{version}/preview`, which returns HTML or JSON suitable for display.
+
 ## Contributing
 
 Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -56,6 +56,7 @@ class TaskController extends Controller
         );
 
         $versions = $task->versions()->latest()->get();
+        $versions->each(fn ($v) => $v->preview_url = route('versions.preview', $v));
         $downloadUrl = null;
 
         // kalau slides & sudah ada file, kirim link unduh
@@ -106,5 +107,45 @@ class TaskController extends Controller
         }
 
         return Storage::disk($version->file_disk)->download($version->file_path, 'slides.pptx');
+    }
+
+    public function preview(Request $r, AiTaskVersion $version)
+    {
+        $project = $version->task->project;
+        abort_unless($project->tenant_id === $r->user()->tenant_id && $project->user_id === $r->user()->id, 403);
+
+        $payload = $version->payload ?? [];
+        $content = $payload['content'] ?? '';
+
+        if (!$content && isset($payload['chunks'][0]['raw'])) {
+            $raw = $payload['chunks'][0]['raw'];
+            $content = $raw['choices'][0]['message']['content'] ?? ($raw['content'][0]['text'] ?? '');
+        }
+
+        $decoded = null;
+        try {
+            $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+        }
+
+        if ($r->wantsJson()) {
+            return response()->json($decoded ?? ['content' => $content]);
+        }
+
+        if (is_array($decoded)) {
+            if (isset($decoded['mindmap']) && is_array($decoded['mindmap'])) {
+                $html = '<ul>';
+                foreach ($decoded['mindmap'] as $item) {
+                    $html .= '<li>'.e($item).'</li>';
+                }
+                $html .= '</ul>';
+                return response($html);
+            }
+            if (isset($decoded['summary'])) {
+                return response('<pre>'.e($decoded['summary']).'</pre>');
+            }
+        }
+
+        return response('<pre>'.e($content).'</pre>');
     }
 }

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -10,3 +10,10 @@ Accepts **GET** and **POST** requests.
 
 - **GET**: Displays a page describing the endpoint.
 - **POST**: Queues a mindmap generation task for the project. Include the CSRF token when submitting the form.
+
+## Previewing Results
+
+`/versions/{version}/preview`
+
+Returns a preview of the task version's payload. If the request expects JSON, the raw payload is returned;
+otherwise a basic HTML representation suitable for the browser is provided.

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware(['auth'])->group(function () {
         ->name('tasks.fallback');
 
     // Versions
+    Route::get('/versions/{version}/preview', [TaskController::class, 'preview'])->name('versions.preview');
     Route::get('/versions/{version}/download', [TaskController::class, 'download'])->name('versions.download');
 
     // Billing


### PR DESCRIPTION
## Summary
- add route and controller logic for previewing task versions
- expose preview URLs in task status response
- document preview endpoint

## Testing
- `./vendor/bin/phpunit` *(fails: Tests\Feature\UploadTest::test_pdf_upload_is_stored_and_returns_url, Tests\Feature\UploadTest::test_invalid_file_type_is_rejected)*

------
https://chatgpt.com/codex/tasks/task_e_6899dd37679c8328804b1afd5a5ee546