### PR TITLE
Handle HTTP errors from AI provider

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -15,6 +15,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 class ProcessAiTask implements ShouldQueue
@@ -61,6 +62,15 @@ class ProcessAiTask implements ShouldQueue
 
             foreach ($chunks as $chunk) {
                 $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
+
+                if (isset($result['error'])) {
+                    Log::error('AI provider error', $result['error']);
+                    $this->task->update([
+                        'status'  => 'failed',
+                        'message' => 'Provider error',
+                    ]);
+                    return;
+                }
 
                 $piece = $result['content']
                     ?? $result['text']
@@ -143,6 +153,15 @@ class ProcessAiTask implements ShouldQueue
 
         foreach ($chunks as $index => $chunk) {
             $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
+
+            if (isset($result['error'])) {
+                Log::error('AI provider error', $result['error']);
+                $this->task->update([
+                    'status'  => 'failed',
+                    'message' => 'Provider error',
+                ]);
+                return;
+            }
 
             $piece = $result['content']
                 ?? $result['text']


### PR DESCRIPTION
## Summary
- Wrap AI provider HTTP calls in try/catch and log failures
- Return structured error details when responses are not successful
- Make ProcessAiTask detect provider errors and mark tasks as failed

## Testing
- `vendor/bin/phpunit` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6899df93e9188328b12e56a952962a9e