### PR TITLE
Add content extraction helper

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -72,9 +72,7 @@ class ProcessAiTask implements ShouldQueue
                     return;
                 }
 
-                $piece = $result['content']
-                    ?? $result['text']
-                    ?? ($result['raw']['choices'][0]['message']['content'] ?? ($result['raw']['content'][0]['text'] ?? null));
+                $piece = AiProvider::extractContent($result);
 
                 $decoded = [];
                 if (is_string($piece) && $piece !== '') {
@@ -163,9 +161,7 @@ class ProcessAiTask implements ShouldQueue
                 return;
             }
 
-            $piece = $result['content']
-                ?? $result['text']
-                ?? ($result['raw']['choices'][0]['message']['content'] ?? ($result['raw']['content'][0]['text'] ?? null));
+            $piece = AiProvider::extractContent($result);
 
             if (is_string($piece) && $piece !== '') {
                 $contents[] = trim($piece);

--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -111,6 +111,34 @@ class AiProvider
         ];
     }
 
+    public static function extractContent(array $result): ?string
+    {
+        $data = $result['raw'] ?? $result;
+
+        if (isset($data['content'])) {
+            if (is_string($data['content'])) {
+                return trim($data['content']);
+            }
+            if (is_array($data['content']) && isset($data['content'][0]['text']) && is_string($data['content'][0]['text'])) {
+                return trim($data['content'][0]['text']);
+            }
+        }
+
+        if (isset($data['text']) && is_string($data['text'])) {
+            return trim($data['text']);
+        }
+
+        if (isset($data['choices'][0]['message']['content']) && is_string($data['choices'][0]['message']['content'])) {
+            return trim($data['choices'][0]['message']['content']);
+        }
+
+        if (isset($data['choices'][0]['text']) && is_string($data['choices'][0]['text'])) {
+            return trim($data['choices'][0]['text']);
+        }
+
+        return null;
+    }
+
     private function calculateCost(string $model, int $input, int $output): int
     {
         $pricing = $this->provider === 'anthropic'

--- a/tests/Unit/AiProviderTest.php
+++ b/tests/Unit/AiProviderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AiProvider;
+use PHPUnit\Framework\TestCase;
+
+class AiProviderTest extends TestCase
+{
+    public function test_extract_content_from_openai_response(): void
+    {
+        $result = [
+            'raw' => [
+                'choices' => [
+                    [
+                        'message' => [
+                            'content' => 'Hello from OpenAI',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame('Hello from OpenAI', AiProvider::extractContent($result));
+    }
+
+    public function test_extract_content_from_anthropic_response(): void
+    {
+        $result = [
+            'raw' => [
+                'content' => [
+                    [
+                        'text' => 'Hello from Anthropic',
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame('Hello from Anthropic', AiProvider::extractContent($result));
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `AiProvider::extractContent` helper for normalized AI response content
- refactor `ProcessAiTask` to use helper for content extraction
- add unit tests covering OpenAI and Anthropic formats

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: Database file at path [...]/database/database.sqlite does not exist)*
- `./vendor/bin/phpunit --testdox tests/Unit/AiProviderTest.php`

------
https://chatgpt.com/codex/tasks/task_e_6899e0e165008328826741770e3b19a7