### PR TITLE
feat: integrate tokenizer for accurate token counts

### DIFF
--- a/app/Support/TextChunker.php
+++ b/app/Support/TextChunker.php
@@ -16,34 +16,17 @@ class TextChunker
     }
 
     /**
-     * Split text into chunks by token count. Tokens are approximated
-     * by splitting on whitespace.
+     * Split text into chunks by token count using the tokenizer service.
      *
      * @return array<int,string>
      */
-    public static function chunk(string $text, int $maxTokens = 800): array
+    public static function chunk(string $text, int $maxTokens = 15000): array
     {
         $clean = self::clean($text);
         if ($clean === '') {
             return [];
         }
 
-        $tokens = preg_split('/\s+/u', $clean, -1, PREG_SPLIT_NO_EMPTY);
-        $chunks = [];
-        $current = [];
-
-        foreach ($tokens as $token) {
-            $current[] = $token;
-            if (count($current) >= $maxTokens) {
-                $chunks[] = implode(' ', $current);
-                $current = [];
-            }
-        }
-
-        if ($current) {
-            $chunks[] = implode(' ', $current);
-        }
-
-        return $chunks;
+        return Tokenizer::chunk($clean, $maxTokens);
     }
 }

--- a/app/Support/Tokenizer.php
+++ b/app/Support/Tokenizer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Support;
+
+use Yethee\Tiktoken\Encoder;
+use Yethee\Tiktoken\EncoderProvider;
+
+/**
+ * Simple tokenizer wrapper around the tiktoken encoder.
+ */
+class Tokenizer
+{
+    /** @var Encoder|null */
+    protected static ?Encoder $encoder = null;
+
+    /**
+     * Get the encoder instance for the configured model.
+     */
+    public static function encoder(): Encoder
+    {
+        if (self::$encoder instanceof Encoder) {
+            return self::$encoder;
+        }
+
+        $provider = new EncoderProvider();
+        $model = env('AI_MODEL', 'gpt-4o-mini');
+
+        try {
+            self::$encoder = $provider->getForModel($model);
+        } catch (\Throwable $e) {
+            // Fallback to a common encoding if model is unknown
+            self::$encoder = $provider->get('cl100k_base');
+        }
+
+        return self::$encoder;
+    }
+
+    /**
+     * Encode the given text into tokens.
+     *
+     * @return array<int>
+     */
+    public static function encode(string $text): array
+    {
+        return self::encoder()->encode($text);
+    }
+
+    /**
+     * Decode tokens back into text.
+     *
+     * @param array<int> $tokens
+     */
+    public static function decode(array $tokens): string
+    {
+        return self::encoder()->decode($tokens);
+    }
+
+    /**
+     * Count the number of tokens in the given text.
+     */
+    public static function count(string $text): int
+    {
+        return count(self::encode($text));
+    }
+
+    /**
+     * Split text into chunks by token count.
+     *
+     * @return array<int,string>
+     */
+    public static function chunk(string $text, int $maxTokens): array
+    {
+        $chunks = [];
+        $encoder = self::encoder();
+
+        foreach ($encoder->encodeInChunks($text, $maxTokens) as $tokenChunk) {
+            $chunks[] = trim($encoder->decode($tokenChunk));
+        }
+
+        return $chunks;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpoffice/phppresentation": "^1.2",
         "phpoffice/phpword": "^1.4",
         "spatie/pdf-to-text": "^1.54",
-        "stripe/stripe-php": "^14.0"
+        "stripe/stripe-php": "^14.0",
+        "yethee/tiktoken": "^0.11.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3544d34ddc75ab3ea8ce5856891ca2e",
+    "content-hash": "9bfca271007323d72b5ffd54b8f1ed55",
     "packages": [
         {
             "name": "brick/math",
@@ -6796,6 +6796,60 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "yethee/tiktoken",
+            "version": "0.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/yethee/tiktoken-php.git",
+                "reference": "23c689daf1e8da3e40e517f61045f0e125595760"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/yethee/tiktoken-php/zipball/23c689daf1e8da3e40e517f61045f0e125595760",
+                "reference": "23c689daf1e8da3e40e517f61045f0e125595760",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/service-contracts": "^2.5 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^13",
+                "mikey179/vfsstream": "^1.6.11",
+                "phpbench/phpbench": "^1.2",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.2",
+                "vimeo/psalm": "6.10.0"
+            },
+            "suggest": {
+                "ext-ffi": "To allow use LibEncoder"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yethee\\Tiktoken\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP version of tiktoken",
+            "keywords": [
+                "bpe",
+                "decode",
+                "encode",
+                "openai",
+                "tiktoken",
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/yethee/tiktoken-php/issues",
+                "source": "https://github.com/yethee/tiktoken-php/tree/0.11.0"
+            },
+            "time": "2025-08-10T18:35:54+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/Unit/TextChunkerTest.php
+++ b/tests/Unit/TextChunkerTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use App\Support\TextChunker;
+use App\Support\Tokenizer;
 use PHPUnit\Framework\TestCase;
 
 class TextChunkerTest extends TestCase
@@ -19,5 +20,9 @@ class TextChunkerTest extends TestCase
         $text = 'one two three four five';
         $chunks = TextChunker::chunk($text, 2);
         $this->assertSame(['one two', 'three four', 'five'], $chunks);
+
+        foreach ($chunks as $chunk) {
+            $this->assertLessThanOrEqual(2, Tokenizer::count($chunk));
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Tokenizer service backed by tiktoken
- use tokenizer in TextChunker with real token limits
- update unit tests for tokenizer based chunking

## Testing
- `vendor/bin/phpunit tests/Unit/TextChunkerTest.php`
- `vendor/bin/phpunit` *(fails: Database file at path `/workspace/aiassisten/database/database.sqlite` does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_6899e1c2038c832892147be9544cf12f