### PR TITLE
Log and expose document parsing failures

### DIFF
--- a/app/Exceptions/DocumentParseException.php
+++ b/app/Exceptions/DocumentParseException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Exceptions;
+
+use Exception;
+
+class DocumentParseException extends Exception
+{
+}
+


### PR DESCRIPTION
## Summary
- inject LoggerInterface into DocumentParser and log parse errors
- add DocumentParseException and throw when parsing fails

## Testing
- `composer install --no-interaction --no-scripts`
- `./vendor/bin/phpunit` *(fails: Expected response status code [200] but received 404)*

------
https://chatgpt.com/codex/tasks/task_e_6899e384b64c8328a223916247411ae2