### PR TITLE
Improve AI provider error reporting and task validation

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -63,8 +63,8 @@ class ProcessAiTask implements ShouldQueue
             foreach ($chunks as $chunk) {
                 $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
 
-                if (isset($result['error'])) {
-                    Log::error('AI provider error', $result['error']);
+                if (!empty($result['error']) || !empty($result['raw']['error'])) {
+                    Log::error('AI provider error', $result['error'] ?? ['raw_error' => $result['raw']['error'] ?? null]);
                     $this->task->update([
                         'status'  => 'failed',
                         'message' => 'Provider error',
@@ -152,8 +152,8 @@ class ProcessAiTask implements ShouldQueue
         foreach ($chunks as $index => $chunk) {
             $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
 
-            if (isset($result['error'])) {
-                Log::error('AI provider error', $result['error']);
+            if (!empty($result['error']) || !empty($result['raw']['error'])) {
+                Log::error('AI provider error', $result['error'] ?? ['raw_error' => $result['raw']['error'] ?? null]);
                 $this->task->update([
                     'status'  => 'failed',
                     'message' => 'Provider error',

--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -40,11 +40,23 @@ class AiProvider
         $prompt = "Using locale {$locale}, generate a {$type} in JSON for the following text:\n\n{$text}";
 
         if ($this->provider === 'anthropic' && !env('ANTHROPIC_API_KEY')) {
-            return ['raw' => ['error' => 'missing anthropic api key'], 'input_tokens' => 0, 'output_tokens' => 0, 'cost_cents' => 0];
+            return [
+                'error'        => ['status' => null, 'body' => 'missing anthropic api key'],
+                'raw'          => ['error' => 'missing anthropic api key'],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
         }
 
         if ($this->provider === 'openai' && !env('OPENAI_API_KEY')) {
-            return ['raw' => ['error' => 'missing openai api key'], 'input_tokens' => 0, 'output_tokens' => 0, 'cost_cents' => 0];
+            return [
+                'error'        => ['status' => null, 'body' => 'missing openai api key'],
+                'raw'          => ['error' => 'missing openai api key'],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
         }
 
         try {


### PR DESCRIPTION
## Summary
- Include top-level error details when API keys are missing in `AiProvider`
- Guard against raw provider errors when processing AI tasks

## Testing
- `vendor/bin/phpunit --filter LocalizedRoutesTest` *(fails: Expected response status code [200] but received 404)*


------
https://chatgpt.com/codex/tasks/task_e_6899eb6980a48328b2b8504fb17bc7b8