### PR TITLE
Expose download URLs for task versions

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -56,7 +56,10 @@ class TaskController extends Controller
         );
 
         $versions = $task->versions()->latest()->get();
-        $versions->each(fn ($v) => $v->preview_url = route('versions.preview', $v));
+        $versions->each(function ($v) {
+            $v->preview_url = route('versions.preview', $v);
+            $v->download_url = route('versions.download', $v);
+        });
         $downloadUrl = null;
 
         // kalau slides & sudah ada file, kirim link unduh

--- a/resources/views/components/task-result.blade.php
+++ b/resources/views/components/task-result.blade.php
@@ -34,9 +34,9 @@
                     if (this.versions.length > 0) {
                         this.version = this.versions[0];
                         this.result = this.versions[0].parsed;
-                        this.downloadUrl = this.versions[0].file_path || d.download_url;
                         this.openPreview = `preview-version-${this.versions[0].id}`;
                     }
+                    this.downloadUrl = d.download_url;
                     return;
                 }
                 if (d.status === 'failed') return;
@@ -68,8 +68,8 @@
                                 class="text-xs text-blue-600 dark:text-blue-400 underline"
                                 @click="openPreview = openPreview === `preview-version-${v.id}` ? null : `preview-version-${v.id}`"
                             >Preview</button>
-                            <template x-if="v.file_path">
-                                <a :href="v.file_path" class="text-xs text-violet-600 dark:text-violet-400 underline">Download PPTX</a>
+                            <template x-if="v.download_url">
+                                <a :href="v.download_url" class="text-xs text-violet-600 dark:text-violet-400 underline">Download PPTX</a>
                             </template>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Add download_url attribute to each task version in `TaskController`
- Use new `download_url` in `task-result` component

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Database file at path [database/database.sqlite] does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6899eb99a40c8328bd694de58f33ff60