### PR TITLE
Handle task parsing fallback

### DIFF
--- a/resources/views/components/task-result.blade.php
+++ b/resources/views/components/task-result.blade.php
@@ -2,6 +2,7 @@
 
 <div x-data="{
     url: '{{ route('tasks.show', [$project, $task]) }}',
+    type: '{{ $task->type }}',
     status: null,
     message: null,
     version: null,
@@ -27,7 +28,13 @@
                         try {
                             parsed = content ? JSON.parse(content) : {};
                         } catch (e) {
-                            parsed = { title: content };
+                            if (this.type === 'summarize') {
+                                parsed = { summary: content };
+                            } else if (this.type === 'mindmap') {
+                                parsed = { mindmap: content.split('\n') };
+                            } else {
+                                parsed = { title: content };
+                            }
                         }
                         return { ...v, parsed };
                     });


### PR DESCRIPTION
## Summary
- expose task type in task-result component's Alpine data
- provide summary and mindmap fallbacks when JSON parsing fails

## Testing
- `php artisan test` *(fails: database file does not exist, 31 failed, 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_6899eba8cbd483288976f224f6c2012d