### PR TITLE
Improve context around document parsing failures

### DIFF
--- a/app/Exceptions/DocumentParseException.php
+++ b/app/Exceptions/DocumentParseException.php
@@ -3,8 +3,33 @@
 namespace App\Exceptions;
 
 use Exception;
+use Throwable;
 
 class DocumentParseException extends Exception
 {
+    public function __construct(
+        string $message = '',
+        private ?string $hint = null,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getHint(): ?string
+    {
+        return $this->hint;
+    }
+
+    public function render($request)
+    {
+        $payload = ['message' => __($this->getMessage())];
+
+        if ($this->hint) {
+            $payload['hint'] = __($this->hint);
+        }
+
+        return response()->json($payload, 500);
+    }
 }
 

--- a/app/Services/DocumentParser.php
+++ b/app/Services/DocumentParser.php
@@ -6,6 +6,7 @@ use App\Exceptions\DocumentParseException;
 use Illuminate\Support\Facades\Storage;
 use PhpOffice\PhpWord\IOFactory;
 use Psr\Log\LoggerInterface;
+use Spatie\PdfToText\Exceptions\CouldNotExtractText;
 use Spatie\PdfToText\Pdf;
 
 class DocumentParser
@@ -32,7 +33,17 @@ class DocumentParser
                 'message' => $e->getMessage(),
             ]);
 
-            throw new DocumentParseException("Failed to parse document at {$path}", 0, $e);
+            $hint = $e->getMessage();
+            if ($e instanceof CouldNotExtractText) {
+                $hint = __('PDF tool missing. Please install the necessary binary.');
+            }
+
+            throw new DocumentParseException(
+                __("Failed to parse document at :path", ['path' => $path]),
+                $hint,
+                0,
+                $e
+            );
         }
     }
 

--- a/tests/Unit/DocumentParseExceptionTest.php
+++ b/tests/Unit/DocumentParseExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Exceptions\DocumentParseException;
+use PHPUnit\Framework\TestCase;
+
+class DocumentParseExceptionTest extends TestCase
+{
+    public function test_hint_is_stored(): void
+    {
+        $exception = new DocumentParseException('Failed', 'PDF tool missing');
+        $this->assertSame('PDF tool missing', $exception->getHint());
+    }
+}


### PR DESCRIPTION
## Summary
- enrich `DocumentParseException` with optional hint and localized rendering
- supply parsing context from `DocumentParser`, including a PDF-tool-missing hint
- cover hint behaviour with a unit test

## Testing
- `./vendor/bin/phpunit 2>&1 | tail -n 20` *(fails: Database file at path [/workspace/aiassisten/database/database.sqlite] does not exist)*
- `./vendor/bin/phpunit tests/Unit/DocumentParseExceptionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6899ed0b7f6c83289531bc006c91e865