### PR TITLE
Add PowerPoint parsing support and tests

### DIFF
--- a/app/Services/DocumentParser.php
+++ b/app/Services/DocumentParser.php
@@ -4,7 +4,8 @@ namespace App\Services;
 
 use App\Exceptions\DocumentParseException;
 use Illuminate\Support\Facades\Storage;
-use PhpOffice\PhpWord\IOFactory;
+use PhpOffice\PhpPresentation\IOFactory as PptIOFactory;
+use PhpOffice\PhpWord\IOFactory as WordIOFactory;
 use Psr\Log\LoggerInterface;
 use Spatie\PdfToText\Pdf;
 
@@ -23,6 +24,7 @@ class DocumentParser
             return match ($ext) {
                 'pdf' => Pdf::getText($fullPath),
                 'doc', 'docx' => $this->parseWord($fullPath),
+                'ppt', 'pptx' => $this->parsePowerPoint($fullPath),
                 'txt' => (string) Storage::disk($disk)->get($path),
                 default => '',
             };
@@ -38,13 +40,62 @@ class DocumentParser
 
     protected function parseWord(string $fullPath): string
     {
-        $phpWord = IOFactory::load($fullPath);
+        $phpWord = WordIOFactory::load($fullPath);
         $text = '';
 
         foreach ($phpWord->getSections() as $section) {
             foreach ($section->getElements() as $element) {
                 if (method_exists($element, 'getText')) {
                     $text .= $element->getText()."\n";
+                }
+            }
+        }
+
+        return trim($text);
+    }
+
+    protected function parsePowerPoint(string $fullPath): string
+    {
+        $presentation = PptIOFactory::load($fullPath);
+        $text = '';
+
+        foreach ($presentation->getAllSlides() as $slide) {
+            foreach ($slide->getShapeCollection() as $shape) {
+                if (method_exists($shape, 'getParagraphs')) {
+                    foreach ($shape->getParagraphs() as $paragraph) {
+                        foreach ($paragraph->getRichTextElements() as $element) {
+                            $content = trim($element->getText());
+                            if ($content !== '') {
+                                $text .= $content . "\n";
+                            }
+                        }
+                    }
+                } elseif (method_exists($shape, 'getText')) {
+                    $content = trim($shape->getText());
+                    if ($content !== '') {
+                        $text .= $content . "\n";
+                    }
+                }
+            }
+
+            $notes = $slide->getNote();
+            if ($notes) {
+                foreach ($notes->getShapeCollection() as $noteShape) {
+                    if (method_exists($noteShape, 'getParagraphs')) {
+                        foreach ($noteShape->getParagraphs() as $paragraph) {
+                            foreach ($paragraph->getRichTextElements() as $element) {
+                                $content = trim($element->getText());
+                                if ($content !== '') {
+                                    $text .= $content . "\n";
+                                }
+                            }
+                        }
+                    } elseif (method_exists($noteShape, 'getText')) {
+                        $content = trim($noteShape->getText());
+                        if ($content !== '') {
+                            $text .= $content . "\n";
+                        }
+                    }
                 }
             }
         }

--- a/tests/Feature/ProjectControllerTest.php
+++ b/tests/Feature/ProjectControllerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{AiProject, Tenant, User};
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use PhpOffice\PhpPresentation\IOFactory as PptIOFactory;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use Tests\TestCase;
+
+class ProjectControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_rejects_unsupported_file(): void
+    {
+        Storage::fake('private');
+
+        $tenant = Tenant::create([
+            'id'   => (string) Str::uuid(),
+            'name' => 'T',
+            'slug' => 't',
+        ]);
+
+        $user = User::factory()->create(['tenant_id' => $tenant->id]);
+
+        $file = UploadedFile::fake()->create('test.jpg', 100, 'image/jpeg');
+
+        $response = $this->actingAs($user)->post('/projects', [
+            'title' => 'Test',
+            'file'  => $file,
+        ]);
+
+        $response->assertSessionHasErrors('file');
+    }
+
+    public function test_store_accepts_pptx_and_parses_text(): void
+    {
+        Storage::fake('private');
+
+        $tenant = Tenant::create([
+            'id'   => (string) Str::uuid(),
+            'name' => 'T',
+            'slug' => 't',
+        ]);
+
+        $user = User::factory()->create(['tenant_id' => $tenant->id]);
+
+        $presentation = new PhpPresentation();
+        $slide = $presentation->getActiveSlide();
+        $shape = $slide->createRichTextShape();
+        $shape->createTextRun('Hello PPTX');
+
+        $temp = tempnam(sys_get_temp_dir(), 'ppt');
+        $writer = PptIOFactory::createWriter($presentation, 'PowerPoint2007');
+        $writer->save($temp);
+        $upload = new UploadedFile($temp, 'sample.pptx', null, null, true);
+
+        $response = $this->actingAs($user)->post('/projects', [
+            'title' => 'My PPT',
+            'file'  => $upload,
+        ]);
+
+        $response->assertSessionHasNoErrors();
+
+        $project = AiProject::first();
+        $this->assertSame('Hello PPTX', $project->source_text);
+    }
+}

--- a/tests/Unit/DocumentParserTest.php
+++ b/tests/Unit/DocumentParserTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\DocumentParser;
+use Illuminate\Support\Facades\Storage;
+use PhpOffice\PhpPresentation\IOFactory as PptIOFactory;
+use PhpOffice\PhpPresentation\PhpPresentation;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+
+class DocumentParserTest extends TestCase
+{
+    public function test_parses_pptx_file(): void
+    {
+        Storage::fake('local');
+
+        $presentation = new PhpPresentation();
+        $slide = $presentation->getActiveSlide();
+        $shape = $slide->createRichTextShape();
+        $shape->createTextRun('Hello PPTX');
+
+        $path = 'sample.pptx';
+        $writer = PptIOFactory::createWriter($presentation, 'PowerPoint2007');
+        $writer->save(Storage::disk('local')->path($path));
+
+        $parser = new DocumentParser(new NullLogger());
+        $text = $parser->parse('local', $path);
+
+        $this->assertSame('Hello PPTX', $text);
+    }
+
+    public function test_returns_empty_string_for_unsupported_format(): void
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('file.xyz', 'data');
+
+        $parser = new DocumentParser(new NullLogger());
+        $text = $parser->parse('local', 'file.xyz');
+
+        $this->assertSame('', $text);
+    }
+}


### PR DESCRIPTION
## Summary
- parse PPT and PPTX documents via PhpPresentation in DocumentParser
- cover supported and unsupported formats with unit tests
- ensure project creation rejects unsupported file uploads and parses PPTX text

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA ./vendor/bin/phpunit tests/Unit/DocumentParserTest.php tests/Feature/ProjectControllerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_6899ed071520832898abca8b0a707821