### PR TITLE
Gracefully handle document parsing failures

### DIFF
--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\AiProject;
 use App\Services\DocumentParser;
+use App\Exceptions\DocumentParseException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -43,7 +44,12 @@ class ProjectController extends Controller
         if ($r->hasFile('file')) {
             $filename = $r->file('file')->getClientOriginalName();
             $path = $r->file('file')->store("uploads/{$r->user()->tenant_id}", $disk);
-            $text = $parser->parse($disk, $path);
+
+            try {
+                $text = $parser->parse($disk, $path);
+            } catch (DocumentParseException $e) {
+                return back()->withErrors(['file' => 'Unable to parse the uploaded document.']);
+            }
         }
 
         AiProject::create([


### PR DESCRIPTION
## Summary
- catch `DocumentParseException` when parsing uploaded files and return a validation error instead of a 500

## Testing
- `./vendor/bin/phpunit` *(fails: Database file at path /workspace/aiassisten/database/database.sqlite does not exist. Tests: 36, Assertions: 9, Errors: 27, Failures: 4, Warnings: 2.)*

------
https://chatgpt.com/codex/tasks/task_e_6899f10f08a083289e78317ff0f88795