### PR TITLE
Handle PDF parser failures gracefully

### DIFF
--- a/app/Services/DocumentParser.php
+++ b/app/Services/DocumentParser.php
@@ -11,9 +11,7 @@ use Spatie\PdfToText\Pdf;
 
 class DocumentParser
 {
-    public function __construct(private LoggerInterface $logger)
-    {
-    }
+    public function __construct(private LoggerInterface $logger) {}
 
     public function parse(string $disk, string $path): string
     {
@@ -60,9 +58,19 @@ class DocumentParser
 
             return Pdf::getText($fullPath);
         } catch (\Throwable $e) {
-            $parser = new PdfParser();
+            try {
+                $parser = new PdfParser;
 
-            return $parser->parseFile($fullPath)->getText();
+                return $parser->parseFile($fullPath)->getText();
+            } catch (\Throwable $fallbackException) {
+                $this->logger->error('PDF parsing failed using both parsers', [
+                    'path' => $fullPath,
+                    'spatie_error' => $e->getMessage(),
+                    'smalot_error' => $fallbackException->getMessage(),
+                ]);
+
+                return '';
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add nested try/catch to PDF parsing fallback
- log both parser failures and return empty string

## Testing
- `vendor/bin/pint app/Services/DocumentParser.php`
- `vendor/bin/phpunit` *(fails: Database file at path [...] does not exist; 27 errors, 4 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6899f1d4dc908328bb0959f88e9031ab