### PR TITLE
Normalize text before building AI prompt

### DIFF
--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -37,6 +37,8 @@ class AiProvider
             $text = (string) Storage::disk($project->source_disk)->get($project->source_path);
         }
 
+        $text = mb_convert_encoding($text ?? '', 'UTF-8', 'UTF-8');
+
         $prompt = "Using locale {$locale}, generate a {$type} in JSON for the following text:\n\n{$text}";
 
         if ($this->provider === 'anthropic' && !env('ANTHROPIC_API_KEY')) {


### PR DESCRIPTION
## Summary
- normalize input text to UTF-8 before constructing AI prompt

## Testing
- `php artisan test` *(fails: 31 failed, 1 warning, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899f514d1f88328a3a5cc7b80c739c6