### PR TITLE
Sanitize AI prompt placeholders

### DIFF
--- a/tests/Unit/AiProviderPromptTest.php
+++ b/tests/Unit/AiProviderPromptTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AiProvider;
+use Illuminate\Container\Container;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class AiProviderPromptTest extends TestCase
+{
+    public function test_prompt_placeholders_are_resolved(): void
+    {
+        $container = new Container();
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+        $container->singleton('http', fn () => new Factory());
+
+        $captured = null;
+        Http::fake(function ($request) use (&$captured) {
+            $captured = $request->data()['messages'][0]['content'] ?? '';
+            return Http::response([
+                'usage' => ['prompt_tokens' => 0, 'completion_tokens' => 0],
+                'choices' => [["message" => ['content' => '{}']]],
+            ]);
+        });
+
+        putenv('OPENAI_API_KEY=test');
+        putenv('AI_PROVIDER=openai');
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+            public $slideTemplate = null;
+        };
+
+        $provider = new AiProvider();
+        $provider->generate($project, 'slides', 'id', 'Demo {{danger}} text');
+
+        $template = \App\Models\SlideTemplate::defaultTheme();
+        $themeJson = json_encode([
+            'theme' => [
+                'palette' => $template['palette'],
+                'font' => $template['font'],
+                'layout' => $template['layout'],
+                'background_default' => $template['background_default'],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('Buat 5–10 slides', $captured);
+        $this->assertStringContainsString($themeJson, $captured);
+        $this->assertStringContainsString('Demo {danger} text', $captured);
+        $this->assertStringNotContainsString('{{', $captured);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize source text and replace AI prompt placeholders using `strtr`
- add runtime guard to prevent unresolved `{{...}}` markers
- cover prompt substitution with unit test

## Testing
- `vendor/bin/phpunit` *(fails: Vite manifest not found, tiktoken vocab download)*
- `vendor/bin/phpunit tests/Unit/AiProviderPromptTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689a360f8f88832880465fd464d26c50