### PR TITLE
feat: cache ai provider responses

### DIFF
--- a/app/Jobs/ProcessAiTask.php
+++ b/app/Jobs/ProcessAiTask.php
@@ -28,7 +28,7 @@ class ProcessAiTask implements ShouldQueue
     public int $tries = 3;
     public int $backoff = 10;
 
-    public function __construct(public AiTask $task, public string $locale)
+    public function __construct(public AiTask $task, public string $locale, public bool $useCache = true)
     {
     }
 
@@ -77,7 +77,8 @@ class ProcessAiTask implements ShouldQueue
             $payloadChunks = [];
 
             foreach ($chunks as $index => $chunk) {
-                $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
+                $result = ($this->useCache ? $provider : $provider->withoutCache())
+                    ->generate($project, $this->task->type, $this->locale, $chunk);
 
                 if (!empty($result['error']) || !empty($result['raw']['error'])) {
                     Log::error('AI provider error', $result['error'] ?? ['raw_error' => $result['raw']['error'] ?? null]);
@@ -216,7 +217,8 @@ class ProcessAiTask implements ShouldQueue
         $contents = [];
 
         foreach ($chunks as $index => $chunk) {
-            $result = $provider->generate($project, $this->task->type, $this->locale, $chunk);
+            $result = ($this->useCache ? $provider : $provider->withoutCache())
+                ->generate($project, $this->task->type, $this->locale, $chunk);
 
             if (!empty($result['error']) || !empty($result['raw']['error'])) {
                 Log::error('AI provider error', $result['error'] ?? ['raw_error' => $result['raw']['error'] ?? null]);

--- a/tests/Unit/AiProviderCacheTest.php
+++ b/tests/Unit/AiProviderCacheTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AiProvider;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class AiProviderCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Facade::clearResolvedInstances();
+        $container = new Container();
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+        $container->singleton('http', fn () => new Factory());
+        $container->singleton('cache', fn () => new Repository(new ArrayStore()));
+        putenv('OPENAI_API_KEY=test');
+        putenv('AI_PROVIDER=openai');
+    }
+
+    public function test_cached_results_skip_api_call(): void
+    {
+        $count = 0;
+        Http::fake(function ($request) use (&$count) {
+            $count++;
+            return Http::response([
+                'usage' => ['prompt_tokens' => 0, 'completion_tokens' => 0],
+                'choices' => [["message" => ['content' => '{}']]],
+            ]);
+        });
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+            public $slideTemplate = null;
+        };
+
+        $provider = new AiProvider();
+        $first = $provider->generate($project, 'summary', 'en', 'Demo text');
+        $second = $provider->generate($project, 'summary', 'en', 'Demo text');
+
+        $this->assertSame($first, $second);
+        $this->assertSame(1, $count);
+    }
+
+    public function test_cache_can_be_bypassed(): void
+    {
+        $count = 0;
+        Http::fake(function ($request) use (&$count) {
+            $count++;
+            return Http::response([
+                'usage' => ['prompt_tokens' => 0, 'completion_tokens' => 0],
+                'choices' => [["message" => ['content' => '{}']]],
+            ]);
+        });
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+            public $slideTemplate = null;
+        };
+
+        $provider = new AiProvider();
+        $provider->generate($project, 'summary', 'en', 'Demo text');
+        $provider->withoutCache()->generate($project, 'summary', 'en', 'Demo text');
+
+        $this->assertSame(2, $count);
+    }
+}
+

--- a/tests/Unit/AiProviderPromptTest.php
+++ b/tests/Unit/AiProviderPromptTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use App\Services\AiProvider;
 use Illuminate\Container\Container;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
@@ -13,10 +15,12 @@ class AiProviderPromptTest extends TestCase
 {
     public function test_prompt_placeholders_are_resolved(): void
     {
+        Facade::clearResolvedInstances();
         $container = new Container();
         Container::setInstance($container);
         Facade::setFacadeApplication($container);
         $container->singleton('http', fn () => new Factory());
+        $container->singleton('cache', fn () => new Repository(new ArrayStore()));
 
         $captured = null;
         Http::fake(function ($request) use (&$captured) {


### PR DESCRIPTION
## Summary
- cache AI responses keyed by prompt hash with optional cache bypass
- allow ProcessAiTask to opt out of caching
- test AI provider caching and bypass logic

## Testing
- `./vendor/bin/phpunit tests/Unit/AiProviderCacheTest.php tests/Unit/AiProviderPromptTest.php`
- `./vendor/bin/phpunit tests/Unit` *(fails: Yethee\Tiktoken\Exception\IOError: Could not open stream for URI: https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken)*

------
https://chatgpt.com/codex/tasks/task_e_689a3f38a9c8832887961af3ffc9bdab