### PR TITLE
Aggregate AI task pieces into JSON

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -126,11 +126,6 @@ class TaskController extends Controller
         $payload = $version->payload ?? [];
         $content = $payload['content'] ?? '';
 
-        if (!$content && isset($payload['chunks'][0]['raw'])) {
-            $raw = $payload['chunks'][0]['raw'];
-            $content = $raw['choices'][0]['message']['content'] ?? ($raw['content'][0]['text'] ?? '');
-        }
-
         $decoded = null;
         try {
             $decoded = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
@@ -142,16 +137,19 @@ class TaskController extends Controller
         }
 
         if (is_array($decoded)) {
+            $html = '';
+            if (isset($decoded['summary'])) {
+                $html .= '<pre>'.e($decoded['summary']).'</pre>';
+            }
             if (isset($decoded['mindmap']) && is_array($decoded['mindmap'])) {
-                $html = '<ul>';
+                $html .= '<ul>';
                 foreach ($decoded['mindmap'] as $item) {
                     $html .= '<li>'.e($item).'</li>';
                 }
                 $html .= '</ul>';
-                return response($html);
             }
-            if (isset($decoded['summary'])) {
-                return response('<pre>'.e($decoded['summary']).'</pre>');
+            if ($html !== '') {
+                return response($html);
             }
         }
 

--- a/resources/views/components/task-result.blade.php
+++ b/resources/views/components/task-result.blade.php
@@ -20,21 +20,11 @@
                 if (d.status === 'done') {
                     this.versions = d.versions.map(v => {
                         let content = v.payload?.content || '';
-                        let raw = v.payload?.chunks?.[0]?.raw;
-                        if (!content && raw) {
-                            content = raw?.choices?.[0]?.message?.content || raw?.content?.[0]?.text || '';
-                        }
                         let parsed = {};
                         try {
                             parsed = content ? JSON.parse(content) : {};
                         } catch (e) {
-                            if (this.type === 'summarize') {
-                                parsed = { summary: content };
-                            } else if (this.type === 'mindmap') {
-                                parsed = { mindmap: content.split('\n') };
-                            } else {
-                                parsed = { title: content };
-                            }
+                            parsed = {};
                         }
                         return { ...v, parsed };
                     });


### PR DESCRIPTION
## Summary
- Decode non-slide AI task pieces as JSON and collect `summary` and `mindmap` data
- Fail tasks with no valid JSON and store merged content as a single JSON string
- Update preview endpoint and task result component to expect aggregated JSON

## Testing
- `vendor/bin/phpunit` *(fails: Vite manifest not found, multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689a416a611883289237fdc4756ebd45