### PR TITLE
Add chat support to AiProvider with tests

### DIFF
--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -38,6 +38,97 @@ class AiProvider
         return $this;
     }
 
+    public function chat(AiProject $project, string $locale, string $message): array
+    {
+        if ($this->provider === 'anthropic' && !env('ANTHROPIC_API_KEY')) {
+            return [
+                'error'        => ['status' => null, 'body' => 'missing anthropic api key'],
+                'raw'          => ['error' => 'missing anthropic api key'],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
+        }
+
+        if ($this->provider === 'openai' && !env('OPENAI_API_KEY')) {
+            return [
+                'error'        => ['status' => null, 'body' => 'missing openai api key'],
+                'raw'          => ['error' => 'missing openai api key'],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
+        }
+
+        try {
+            if ($this->provider === 'anthropic') {
+                $response = Http::withHeaders([
+                        'x-api-key' => env('ANTHROPIC_API_KEY'),
+                        'anthropic-version' => '2023-06-01',
+                    ])
+                    ->connectTimeout((int) env('AI_CONNECT_TIMEOUT', 30))
+                    ->timeout((int) env('AI_HTTP_TIMEOUT', 300))
+                    ->retry((int) env('AI_HTTP_RETRY', 2), (int) env('AI_HTTP_RETRY_MS', 1500))
+                    ->post(self::ANTHROPIC_ENDPOINT, [
+                        'model' => $this->model,
+                        'max_tokens' => 1024,
+                        'messages' => [
+                            ['role' => 'user', 'content' => $message],
+                        ],
+                    ]);
+            } else {
+                $response = Http::withToken(env('OPENAI_API_KEY'))
+                    ->connectTimeout((int) env('AI_CONNECT_TIMEOUT', 30))
+                    ->timeout((int) env('AI_HTTP_TIMEOUT', 300))
+                    ->retry((int) env('AI_HTTP_RETRY', 2), (int) env('AI_HTTP_RETRY_MS', 1500))
+                    ->post(self::OPENAI_ENDPOINT, [
+                        'model' => $this->model,
+                        'messages' => [
+                            ['role' => 'user', 'content' => $message],
+                        ],
+                    ]);
+            }
+        } catch (Throwable $e) {
+            Log::error('AI provider request exception', ['exception' => $e]);
+
+            return [
+                'error'        => ['status' => null, 'body' => $e->getMessage()],
+                'raw'          => [],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
+        }
+
+        if (!$response->successful()) {
+            Log::error('AI provider request failed', [
+                'status' => $response->status(),
+                'body' => $response->body(),
+            ]);
+
+            return [
+                'error'        => ['status' => $response->status(), 'body' => $response->json() ?? $response->body()],
+                'raw'          => $response->json() ?? [],
+                'input_tokens' => 0,
+                'output_tokens' => 0,
+                'cost_cents'   => 0,
+            ];
+        }
+
+        $data = $response->json();
+        $usage = $data['usage'] ?? [];
+        $input = $usage['prompt_tokens'] ?? ($usage['input_tokens'] ?? 0);
+        $output = $usage['completion_tokens'] ?? ($usage['output_tokens'] ?? 0);
+        $cost_cents = $this->calculateCost($this->model, $input, $output);
+
+        return [
+            'raw' => $data,
+            'input_tokens' => $input,
+            'output_tokens' => $output,
+            'cost_cents' => $cost_cents,
+        ];
+    }
+
     public function generate(AiProject $project, string $type, string $locale = 'en', ?string $text = null): array
     {
         $text = $text ?? ($project->source_text ?? '');

--- a/tests/Unit/AiProviderChatTest.php
+++ b/tests/Unit/AiProviderChatTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AiProvider;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class AiProviderChatTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Facade::clearResolvedInstances();
+        $container = new Container();
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+        $container->singleton('http', fn () => new Factory());
+        $container->singleton('cache', fn () => new Repository(new ArrayStore()));
+    }
+
+    public function test_chat_returns_reply_text(): void
+    {
+        Http::fake(function ($request) {
+            return Http::response([
+                'usage' => ['prompt_tokens' => 5, 'completion_tokens' => 7],
+                'choices' => [
+                    ['message' => ['content' => 'Hi there!']],
+                ],
+            ]);
+        });
+
+        putenv('OPENAI_API_KEY=test');
+        putenv('AI_PROVIDER=openai');
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+        };
+
+        $provider = new AiProvider();
+        $result = $provider->chat($project, 'en', 'Hello');
+
+        $this->assertSame('Hi there!', AiProvider::extractContent($result));
+        $this->assertSame(5, $result['input_tokens']);
+        $this->assertSame(7, $result['output_tokens']);
+    }
+
+    public function test_chat_returns_error_when_openai_key_missing(): void
+    {
+        putenv('OPENAI_API_KEY');
+        putenv('AI_PROVIDER=openai');
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+        };
+
+        $provider = new AiProvider();
+        $result = $provider->chat($project, 'en', 'Hello');
+
+        $this->assertSame('missing openai api key', $result['error']['body'] ?? null);
+        $this->assertSame('missing openai api key', $result['raw']['error'] ?? null);
+    }
+
+    public function test_chat_returns_error_when_anthropic_key_missing(): void
+    {
+        putenv('ANTHROPIC_API_KEY');
+        putenv('AI_PROVIDER=anthropic');
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+        };
+
+        $provider = new AiProvider();
+        $result = $provider->chat($project, 'en', 'Hello');
+
+        $this->assertSame('missing anthropic api key', $result['error']['body'] ?? null);
+        $this->assertSame('missing anthropic api key', $result['raw']['error'] ?? null);
+    }
+}


### PR DESCRIPTION
## Summary
- add `chat()` to `AiProvider` for user prompt chat completion via OpenAI or Anthropic
- compute token usage & cost, reuse timeout/retry logic
- add unit tests covering reply extraction and missing API key handling

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml tests/Unit/AiProviderChatTest.php`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Vite manifest not found and other HTTP errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a5d86d7bc83288124a9258de6cda8