### PR TITLE
Handle chat history

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -15,8 +15,10 @@ class ChatController extends Controller
     public function send(Request $request, AiProvider $provider)
     {
         $data = $request->validate([
-            'message' => 'required|string|max:8000',
-            'locale'  => 'nullable|string|max:10',
+            'messages'       => 'required|array|min:1',
+            'messages.*.role'    => 'required|string',
+            'messages.*.content' => 'required|string|max:8000',
+            'locale'        => 'nullable|string|max:10',
         ]);
         $locale = $data['locale'] ?? app()->getLocale();
         $fakeProject = (object)[
@@ -28,7 +30,7 @@ class ChatController extends Controller
             'tenant' => $request->user()->tenant,
         ];
 
-        $result = $provider->chat($fakeProject, $locale, $data['message']);
+        $result = $provider->chat($fakeProject, $locale, $data['messages']);
         $content = \App\Services\AiProvider::extractContent($result);
         return response()->json([
             'ok' => true,

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -21,8 +21,10 @@
 const box = document.getElementById('messages');
 const form = document.getElementById('chatForm');
 const input = document.getElementById('msg');
+let history = [];
 
 function add(role, text){
+  history.push({ role, content: text });
   const item = document.createElement('div');
   item.className = role === 'user' ? 'text-right' : 'text-left';
   item.innerHTML = `<div class="inline-block rounded-2xl px-3 py-2 ${role==='user'?'bg-violet-600 text-white':'bg-gray-100'}">${text.replace(/</g,'&lt;')}</div>`;
@@ -33,9 +35,13 @@ form.addEventListener('submit', async (e) => {
   e.preventDefault();
   const text = input.value.trim(); if(!text) return;
   add('user', text); input.value='';
-  const res = await fetch('{{ route('chat.send') }}', { method:'POST', headers:{'X-CSRF-TOKEN': '{{ csrf_token() }}', 'Accept':'application/json','Content-Type':'application/json'}, body: JSON.stringify({message:text})});
+  const res = await fetch('{{ route('chat.send') }}', {
+    method:'POST',
+    headers:{'X-CSRF-TOKEN': '{{ csrf_token() }}', 'Accept':'application/json','Content-Type':'application/json'},
+    body: JSON.stringify({messages: history})
+  });
   const data = await res.json();
-  add('bot', data.reply || 'No reply');
+  add('assistant', data.reply || 'No reply');
 });
 </script>
 @endsection

--- a/tests/Unit/AiProviderChatTest.php
+++ b/tests/Unit/AiProviderChatTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Services\AiProvider;
+use Illuminate\Cache\ArrayStore;
+use Illuminate\Cache\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Http\Client\Factory;
+use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class AiProviderChatTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Facade::clearResolvedInstances();
+        $container = new Container();
+        Container::setInstance($container);
+        Facade::setFacadeApplication($container);
+        $container->singleton('http', fn () => new Factory());
+        $container->singleton('cache', fn () => new Repository(new ArrayStore()));
+        putenv('OPENAI_API_KEY=test');
+        putenv('AI_PROVIDER=openai');
+    }
+
+    public function test_messages_array_is_sent_to_provider(): void
+    {
+        $captured = null;
+        Http::fake(function ($request) use (&$captured) {
+            $captured = $request->data()['messages'] ?? null;
+            return Http::response([
+                'usage' => ['prompt_tokens' => 0, 'completion_tokens' => 0],
+                'choices' => [["message" => ['content' => 'hi']]],
+            ]);
+        });
+
+        $project = new class extends \App\Models\AiProject {
+            protected static function booted(): void {}
+            public $slideTemplate = null;
+        };
+
+        $provider = new AiProvider();
+        $messages = [
+            ['role' => 'user', 'content' => 'Hello'],
+            ['role' => 'assistant', 'content' => 'Hi'],
+            ['role' => 'user', 'content' => 'How are you?'],
+        ];
+
+        $provider->chat($project, 'en', $messages);
+
+        $this->assertSame($messages, $captured);
+    }
+}


### PR DESCRIPTION
## Summary
- Track chat history client-side and send complete message arrays to the server
- Pass conversation history through ChatController to AiProvider and forward to provider APIs
- Add unit test verifying message history is sent in API call

## Testing
- `./vendor/bin/phpunit tests/Unit/AiProviderChatTest.php`
- `./vendor/bin/phpunit --testsuite Unit` *(fails: Could not open stream for URI: https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken)*

------
https://chatgpt.com/codex/tasks/task_e_689a5ea3717083289752ced714e9fa0f