### PR TITLE
Refactor AI chat to handle conversation history

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -47,7 +47,15 @@ class ChatController extends Controller
             'content' => $data['message'],
         ]);
 
-        $result = $provider->chat($fakeProject, $locale, $data['message']);
+        $messages = $session->messages()
+            ->orderByDesc('created_at')
+            ->take(20)
+            ->get(['role', 'content'])
+            ->reverse()
+            ->values()
+            ->toArray();
+
+        $result = $provider->chat($fakeProject, $locale, $messages);
         $content = \App\Services\AiProvider::extractContent($result) ?: 'Sorry, no response.';
 
         $session->messages()->create([

--- a/app/Services/AiProvider.php
+++ b/app/Services/AiProvider.php
@@ -38,7 +38,7 @@ class AiProvider
         return $this;
     }
 
-    public function chat(AiProject $project, string $locale, string $message): array
+    public function chat(AiProject $project, string $locale, array $messages): array
     {
         if ($this->provider === 'anthropic' && !env('ANTHROPIC_API_KEY')) {
             return [
@@ -72,9 +72,7 @@ class AiProvider
                     ->post(self::ANTHROPIC_ENDPOINT, [
                         'model' => $this->model,
                         'max_tokens' => 1024,
-                        'messages' => [
-                            ['role' => 'user', 'content' => $message],
-                        ],
+                        'messages' => $messages,
                     ]);
             } else {
                 $response = Http::withToken(env('OPENAI_API_KEY'))
@@ -83,9 +81,7 @@ class AiProvider
                     ->retry((int) env('AI_HTTP_RETRY', 2), (int) env('AI_HTTP_RETRY_MS', 1500))
                     ->post(self::OPENAI_ENDPOINT, [
                         'model' => $this->model,
-                        'messages' => [
-                            ['role' => 'user', 'content' => $message],
-                        ],
+                        'messages' => $messages,
                     ]);
             }
         } catch (Throwable $e) {

--- a/tests/Unit/AiProviderChatTest.php
+++ b/tests/Unit/AiProviderChatTest.php
@@ -43,7 +43,9 @@ class AiProviderChatTest extends TestCase
         };
 
         $provider = new AiProvider();
-        $result = $provider->chat($project, 'en', 'Hello');
+        $result = $provider->chat($project, 'en', [
+            ['role' => 'user', 'content' => 'Hello'],
+        ]);
 
         $this->assertSame('Hi there!', AiProvider::extractContent($result));
         $this->assertSame(5, $result['input_tokens']);
@@ -60,7 +62,9 @@ class AiProviderChatTest extends TestCase
         };
 
         $provider = new AiProvider();
-        $result = $provider->chat($project, 'en', 'Hello');
+        $result = $provider->chat($project, 'en', [
+            ['role' => 'user', 'content' => 'Hello'],
+        ]);
 
         $this->assertSame('missing openai api key', $result['error']['body'] ?? null);
         $this->assertSame('missing openai api key', $result['raw']['error'] ?? null);
@@ -76,7 +80,9 @@ class AiProviderChatTest extends TestCase
         };
 
         $provider = new AiProvider();
-        $result = $provider->chat($project, 'en', 'Hello');
+        $result = $provider->chat($project, 'en', [
+            ['role' => 'user', 'content' => 'Hello'],
+        ]);
 
         $this->assertSame('missing anthropic api key', $result['error']['body'] ?? null);
         $this->assertSame('missing anthropic api key', $result['raw']['error'] ?? null);


### PR DESCRIPTION
## Summary
- Pass recent chat session history to AI provider
- Update AI provider interface to accept array of messages
- Adjust unit tests for new chat API

## Testing
- `./vendor/bin/phpunit` *(fails: Tests: 47, Assertions: 77, Errors: 2, Failures: 16, Warnings: 2)*
- `./vendor/bin/phpunit tests/Unit/AiProviderChatTest.php`


------
https://chatgpt.com/codex/tasks/task_e_689a647dfb608328a123ad44a828dacb