### PR TITLE
Refactor chat scripts and harden message rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
-    "name": "aiassisten-main",
+    "name": "aiassisten",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "highlight.js": "^11.9.0"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "alpinejs": "^3.4.2",
@@ -1836,6 +1839,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/highlight.js": {
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
+            "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/is-binary-path": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
         "postcss": "^8.4.31",
         "tailwindcss": "^3.1.0",
         "vite": "^6.0.11"
+    },
+    "dependencies": {
+        "highlight.js": "^11.9.0"
     }
 }

--- a/resources/js/chat.js
+++ b/resources/js/chat.js
@@ -1,0 +1,71 @@
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github.css';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const box = document.getElementById('messages');
+  const form = document.getElementById('chatForm');
+  const input = document.getElementById('msg');
+  const dataEl = document.getElementById('chat-data');
+  const history = dataEl ? JSON.parse(dataEl.dataset.messages || '[]') : [];
+
+  function renderContent(container, text) {
+    const fence = /```(\w+)?\n([\s\S]*?)```/g;
+    let lastIndex = 0;
+    let match;
+    while ((match = fence.exec(text)) !== null) {
+      const [full, lang, code] = match;
+      const before = text.slice(lastIndex, match.index);
+      if (before.trim()) {
+        const p = document.createElement('p');
+        p.textContent = before.trim();
+        container.appendChild(p);
+      }
+      const pre = document.createElement('pre');
+      const codeEl = document.createElement('code');
+      if (lang) codeEl.className = lang;
+      codeEl.textContent = code.trim();
+      pre.appendChild(codeEl);
+      container.appendChild(pre);
+      hljs.highlightElement(codeEl);
+      lastIndex = match.index + full.length;
+    }
+    const after = text.slice(lastIndex);
+    if (after.trim()) {
+      const p = document.createElement('p');
+      p.textContent = after.trim();
+      container.appendChild(p);
+    }
+  }
+
+  function add(role, text) {
+    const item = document.createElement('div');
+    item.className = role === 'user' ? 'text-right' : 'text-left';
+    const bubble = document.createElement('div');
+    bubble.className = `inline-block rounded-2xl px-3 py-2 whitespace-pre-wrap ${role === 'user' ? 'bg-violet-600 text-white' : 'bg-gray-100'}`;
+    renderContent(bubble, text);
+    item.appendChild(bubble);
+    box.appendChild(item);
+    box.scrollTop = box.scrollHeight;
+  }
+
+  history.forEach(m => add(m.role, m.content));
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    add('user', text);
+    input.value = '';
+    const res = await fetch(form.getAttribute('action'), {
+      method: 'POST',
+      headers: {
+        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    add('bot', data.reply || 'No reply');
+  });
+});

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -10,35 +10,16 @@
 <div class="max-w-3xl mx-auto px-6 lg:px-8 py-8">
   <div id="chat" class="rounded-2xl border bg-white shadow-sm h-[70vh] flex flex-col">
     <div id="messages" class="flex-1 overflow-y-auto p-4 space-y-3 text-sm"></div>
-    <form id="chatForm" class="border-t p-3 flex gap-2">
+    <form id="chatForm" action="{{ route('chat.send') }}" method="POST" class="border-t p-3 flex gap-2">
       @csrf
       <input type="text" name="message" id="msg" class="flex-1 rounded-xl border px-3 py-2" placeholder="Type a message..." autocomplete="off">
       <button class="px-4 py-2 rounded-xl bg-gray-900 text-white">Send</button>
     </form>
   </div>
+  <div id="chat-data" data-messages='@json($messages)' class="hidden"></div>
 </div>
-<script>
-const box = document.getElementById('messages');
-const form = document.getElementById('chatForm');
-const input = document.getElementById('msg');
-
-function add(role, text){
-  const item = document.createElement('div');
-  item.className = role === 'user' ? 'text-right' : 'text-left';
-  item.innerHTML = `<div class="inline-block rounded-2xl px-3 py-2 ${role==='user'?'bg-violet-600 text-white':'bg-gray-100'}">${text.replace(/</g,'&lt;')}</div>`;
-  box.appendChild(item); box.scrollTop = box.scrollHeight;
-}
-
-const history = @json($messages);
-history.forEach(m => add(m.role, m.content));
-
-form.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const text = input.value.trim(); if(!text) return;
-  add('user', text); input.value='';
-  const res = await fetch('{{ route('chat.send') }}', { method:'POST', headers:{'X-CSRF-TOKEN': '{{ csrf_token() }}', 'Accept':'application/json','Content-Type':'application/json'}, body: JSON.stringify({message:text})});
-  const data = await res.json();
-  add('bot', data.reply || 'No reply');
-});
-</script>
 @endsection
+
+@push('scripts')
+  @vite('resources/js/chat.js')
+@endpush


### PR DESCRIPTION
## Summary
- Move chat page inline script into `resources/js/chat.js`
- Safely render messages with DOM APIs and code-fence support using highlight.js
- Add highlight.js dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `./vendor/bin/phpunit` *(fails: Could not open stream for URI https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken)*

------
https://chatgpt.com/codex/tasks/task_e_689a65ea6d88832893f831a9e25d03b0