### PR TITLE
Add meta tags to layout with per-view overrides

### DIFF
--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -1,6 +1,12 @@
 @extends('layouts.app')
 
 @section('title','Chat')
+@section('meta_description','Interact with our AI assistant in real time.')
+@section('canonical', route('chat'))
+@push('meta')
+  <meta property="og:image" content="{{ asset('images/chat-og.png') }}">
+  <meta name="twitter:image" content="{{ asset('images/chat-og.png') }}">
+@endpush
 
 @section('header')
   <h2 class="font-semibold text-xl text-gray-800">Chatbot</h2>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -5,6 +5,22 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="csrf-token" content="{{ csrf_token() }}">
   <title>@yield('title','AI Assistant')</title>
+  <meta name="description" content="@yield('meta_description','')">
+  <link rel="canonical" href="@yield('canonical', url()->current())">
+  <meta property="og:title" content="@yield('og_title', View::yieldContent('title','AI Assistant'))">
+  <meta property="og:description" content="@yield('og_description', View::yieldContent('meta_description',''))">
+  <meta property="og:url" content="@yield('og_url', url()->current())">
+  <meta property="og:type" content="@yield('og_type','website')">
+  @hasSection('og_image')
+    <meta property="og:image" content="@yield('og_image')">
+  @endif
+  <meta name="twitter:card" content="@yield('twitter_card','summary_large_image')">
+  <meta name="twitter:title" content="@yield('twitter_title', View::yieldContent('og_title', View::yieldContent('title','AI Assistant')))">
+  <meta name="twitter:description" content="@yield('twitter_description', View::yieldContent('og_description', View::yieldContent('meta_description','')))">
+  @hasSection('twitter_image')
+    <meta name="twitter:image" content="@yield('twitter_image')">
+  @endif
+  @stack('meta')
   @vite(['resources/css/app.css','resources/js/app.js'])
   @stack('head')
 </head>


### PR DESCRIPTION
## Summary
- add default SEO and social meta tags to layout and support per-view overrides
- demonstrate overriding in chat page with custom description, canonical link and images

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Expected response status code [200] but received 404)*

------
https://chatgpt.com/codex/tasks/task_e_689a676c220083288e42d3f8767ce1e2