### PR TITLE
Use AiProject model in ChatController

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\AiProject;
 use App\Models\ChatSession;
 use App\Services\AiProvider;
 use Illuminate\Http\Request;
@@ -27,14 +28,15 @@ class ChatController extends Controller
             'locale'  => 'nullable|string|max:10',
         ]);
         $locale = $data['locale'] ?? app()->getLocale();
-        $fakeProject = (object)[
-            'id' => 'chat',
-            'title' => 'Chat',
-            'language' => $locale,
+
+        $fakeProject = new AiProject([
+            'id'        => 'chat',
+            'title'     => 'Chat',
+            'language'  => $locale,
             'tenant_id' => $request->user()->tenant_id,
-            'user' => $request->user(),
-            'tenant' => $request->user()->tenant,
-        ];
+        ]);
+        $fakeProject->setRelation('user', $request->user());
+        $fakeProject->setRelation('tenant', $request->user()->tenant);
 
         $session = ChatSession::firstOrCreate(
             ['user_id' => $request->user()->id],


### PR DESCRIPTION
## Summary
- Instantiate `AiProject` for chat sessions and associate user & tenant
- Pass the new `AiProject` to `AiProvider::chat`

## Testing
- `./vendor/bin/phpunit` *(fails: Vite manifest not found and other missing setup)*
- `./vendor/bin/phpunit tests/Unit` *(fails: Yethee\Tiktoken\Exception\IOError)*
- `APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/workspace/aiassisten/database/database.sqlite APP_KEY=base64:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= OPENAI_API_KEY=test AI_PROVIDER=openai php chat_test.php`


------
https://chatgpt.com/codex/tasks/task_e_689a70fdff048328a565a49d12a04234