### PR TITLE
Map bot chat role to assistant for AI provider requests

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -55,6 +55,10 @@ class ChatController extends Controller
             ->get(['role', 'content'])
             ->reverse()
             ->values()
+            ->map(fn($m) => [
+                'role' => $m['role'] === 'bot' ? 'assistant' : $m['role'],
+                'content' => $m['content'],
+            ])
             ->toArray();
 
         $result = $provider->chat($fakeProject, $locale, $messages);


### PR DESCRIPTION
## Summary
- Map stored `bot` role to `assistant` when sending chat messages to AI provider

## Testing
- `php -r 'require "vendor/autoload.php"; use Illuminate\Container\Container; use Illuminate\Support\Facades\Facade; use Illuminate\Http\Client\Factory; use Illuminate\Support\Facades\Http; use Illuminate\Support\Collection; use App\Services\AiProvider; use App\Models\AiProject; $container=new Container; Container::setInstance($container); Facade::setFacadeApplication($container); $container->singleton("http", fn()=>new Factory()); Http::fake(function($request){echo "REQUEST:".$request->body()."\n"; return Http::response(["usage"=>["prompt_tokens"=>5,"completion_tokens"=>7],"choices"=>[["message"=>["content"=>"Hi there!"]]]],200);}); putenv("OPENAI_API_KEY=test"); putenv("AI_PROVIDER=openai"); $fakeProject=new class extends App\Models\AiProject {protected static function booted(): void {}}; $provider=new AiProvider(); $messages=[["role"=>"user","content"=>"Hello"],["role"=>"bot","content"=>"Hi again"]]; $mapped=collect($messages)->map(fn($m)=>["role"=>$m["role"]==="bot"?"assistant":$m["role"],"content"=>$m["content"]])->toArray(); $result=$provider->chat($fakeProject,"en",$mapped); echo "REPLY:".App\Services\AiProvider::extractContent($result)."\n";'`
- `./vendor/bin/phpunit` *(fails: Vite manifest not found; multiple feature tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689a8069e7188328aeab7f0d7543b9a0