### PR TITLE
Add simple Mindmap task form

### DIFF
--- a/resources/views/tasks/mindmap.blade.php
+++ b/resources/views/tasks/mindmap.blade.php
@@ -7,7 +7,27 @@
 @endsection
 
 @section('content')
-  <div class="max-w-7xl mx-auto px-6 py-8">
-    <p>Send a POST request to this endpoint to queue a mindmap task for this project.</p>
+  <div class="max-w-7xl mx-auto px-6 py-8 space-y-6">
+    @if (session('ok'))
+      <div class="rounded-xl border border-emerald-200 bg-emerald-50 text-emerald-800 px-4 py-3">
+        {{ session('ok') }}
+      </div>
+    @endif
+    @if ($errors->any())
+      <div class="rounded-xl border border-rose-200 bg-rose-50 text-rose-800 px-4 py-3">
+        {{ $errors->first() }}
+      </div>
+    @endif
+
+    <p class="text-gray-700">Queue a mindmap generation task for this project.</p>
+
+    <form action="{{ route('tasks.mindmap', $project) }}" method="POST" class="space-y-4">
+      @csrf
+      <button class="px-4 py-2 rounded-xl bg-fuchsia-600 text-white font-semibold hover:opacity-90 transition">
+        Generate Mindmap
+      </button>
+    </form>
+
+    <a href="{{ route('dashboard') }}" class="text-sm text-violet-600 underline">Back to dashboard</a>
   </div>
 @endsection


### PR DESCRIPTION
## Summary
- Replace placeholder Mindmap task view with a form that queues the task and links back to the dashboard
- Add session success/error alerts matching other task UIs

## Testing
- `./vendor/bin/phpunit` *(fails: Vite manifest not found and various 404 responses)*

------
https://chatgpt.com/codex/tasks/task_e_689b6f7b803483288d781222f1f5b225