### PR TITLE
Hash license fields during installation

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -53,10 +53,11 @@ class InstallCommand extends Command
         $purchaseCode = $this->ask('Purchase code');
         $defaultDomain = parse_url(config('app.url'), PHP_URL_HOST) ?? config('app.url');
         $domain = $this->ask('Licensed domain', $defaultDomain);
+
         License::create([
             'tenant_id' => $tenant->id,
-            'purchase_code' => $purchaseCode,
-            'domain' => $domain,
+            'purchase_code' => hash('sha256', $purchaseCode),
+            'domain' => hash('sha256', $domain),
             'activated_at' => now(),
             'status' => 'valid',
         ]);


### PR DESCRIPTION
## Summary
- Hash purchase code and domain using SHA-256 in the install command
- Align license storage with admin license controller behavior

## Testing
- `vendor/bin/phpunit` (fails: Vite manifest not found, route 404s, etc.)

------
https://chatgpt.com/codex/tasks/task_e_689b7278e1248328aef2647af656ff93