### PR TITLE
Enforce license requirement in LicenseGate middleware

### DIFF
--- a/app/Http/Middleware/LicenseGate.php
+++ b/app/Http/Middleware/LicenseGate.php
@@ -1,12 +1,27 @@
 <?php
-namespace App\Http\Middleware;
-use Closure; use Illuminate\Http\Request; use Symfony\Component\HttpFoundation\Response;
 
-class LicenseGate {
-    public function handle(Request $request, Closure $next): Response {
-        $t = $request->user()?->tenant; if (!$t) return abort(403);
-        $status = optional($t->license)->status ?? 'valid';
-        if ($status !== 'valid' && $status !== 'grace') abort(402, __('ui.license_required'));
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class LicenseGate
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $tenant = $request->user()?->tenant;
+
+        if (! $tenant) {
+            abort(403);
+        }
+
+        $license = $tenant->license;
+
+        if (! $license || ! in_array($license->status, ['valid', 'grace'], true)) {
+            abort(402, __('ui.license_required'));
+        }
+
         return $next($request);
     }
 }


### PR DESCRIPTION
## Summary
- ensure LicenseGate requires a license with `valid` or `grace` status
- return HTTP 402 when license is missing or invalid

## Testing
- `./vendor/bin/pint app/Http/Middleware/LicenseGate.php`
- `./vendor/bin/phpunit` *(fails: Vite manifest not found; 2 errors, 16 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689b73b8ede48328892360efbc424f2f