### PR TITLE
feat: add license status bypass

### DIFF
--- a/app/Http/Middleware/LicenseGate.php
+++ b/app/Http/Middleware/LicenseGate.php
@@ -4,6 +4,10 @@ use Closure; use Illuminate\Http\Request; use Symfony\Component\HttpFoundation\R
 
 class LicenseGate {
     public function handle(Request $request, Closure $next): Response {
+        if (env('LICENSE_BYPASS')) {
+            return $next($request);
+        }
+
         $t = $request->user()?->tenant; if (!$t) return abort(403);
         $status = optional($t->license)->status ?? 'valid';
         if ($status !== 'valid' && $status !== 'grace') abort(402, __('ui.license_required'));

--- a/tests/Unit/LicenseGateTest.php
+++ b/tests/Unit/LicenseGateTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Http\Middleware\LicenseGate;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use PHPUnit\Framework\TestCase;
+
+class LicenseGateTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        putenv('LICENSE_BYPASS');
+        unset($_ENV['LICENSE_BYPASS'], $_SERVER['LICENSE_BYPASS']);
+    }
+
+    public function test_bypass_env_allows_request(): void
+    {
+        putenv('LICENSE_BYPASS=true');
+        $_ENV['LICENSE_BYPASS'] = true;
+        $_SERVER['LICENSE_BYPASS'] = true;
+
+        $middleware = new LicenseGate();
+        $request = Request::create('/', 'GET');
+        $request->setUserResolver(fn() => (object)[
+            'tenant' => (object)[
+                'license' => (object)['status' => 'expired']
+            ]
+        ]);
+
+        $response = $middleware->handle($request, fn($req) => new Response('ok', 200));
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+}
+


### PR DESCRIPTION
## Summary
- allow bypassing LicenseGate via `env('LICENSE_BYPASS')`
- cover license bypass with a unit test

## Testing
- `./vendor/bin/phpunit tests/Unit/LicenseGateTest.php`
- `./vendor/bin/phpunit` *(fails: Vite manifest not found, upload tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689b7420c3fc8328be6a116a9a180cd8