### PR TITLE
docs: add license activation references

### DIFF
--- a/docs/env-config.md
+++ b/docs/env-config.md
@@ -14,5 +14,14 @@ The application reads configuration from the `.env` file. Important keys:
 | `FILESYSTEM_DISK` | Default storage disk (`local`, `s3`, etc.). |
 | `MAIL_MAILER` | Mail transport driver (`smtp`, `log`, etc.). |
 | `MAIL_FROM_ADDRESS` | Sender email for notifications. |
+| `ENVATO_API_TOKEN` | Envato personal token for license verification. |
+| `LICENSE_BYPASS` | Set to `true` to skip license verification (development only). |
 
 After editing `.env`, run `php artisan config:clear` to apply changes.
+
+Sample `.env` entries:
+
+```dotenv
+ENVATO_API_TOKEN=your-token-here
+LICENSE_BYPASS=false
+```

--- a/docs/install-shared-hosting.md
+++ b/docs/install-shared-hosting.md
@@ -29,6 +29,8 @@
 
 After completing these steps the application should be reachable at your domain.
 
+Next, finish [License Activation](installation.md#license-activation) by setting `ENVATO_API_TOKEN` and, for development, `LICENSE_BYPASS=true` in `.env`.
+
 ## Troubleshooting
 
 - **Missing PHP extensions**: If the installer reports missing extensions, enable them via cPanel's "Select PHP Version" or contact hosting support.

--- a/docs/install-vps.md
+++ b/docs/install-vps.md
@@ -19,3 +19,5 @@
    - Use `docker compose up -d` to build the containers. Set environment variables in `.env` before running the stack.
 
 The application should now be accessible on the configured domain or IP address.
+
+Next, complete [License Activation](installation.md#license-activation) by setting `ENVATO_API_TOKEN` and, if needed, `LICENSE_BYPASS=true` in your `.env` file.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,3 +20,13 @@
    - `php artisan serve` (or configure Nginx/Apache pointing to `public/`).
 
 The application should now be accessible on the configured domain.
+
+## License Activation
+
+After the application is running, activate your license:
+
+1. Set `ENVATO_API_TOKEN` in `.env`.
+2. Visit `/admin/license` and submit the purchase code and domain.
+3. For development, set `LICENSE_BYPASS=true` to skip verification.
+
+See [license-activation.md](license-activation.md) for more details.


### PR DESCRIPTION
## Summary
- document license activation steps in main installation guide and cross-link from VPS and cPanel installs
- expand environment configuration guide with Envato token and development bypass variables

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/aiassisten/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689b7807a6288328a7ec4d3f3d9c61ae