### PR TITLE
docs: centralize installation prerequisites and link guides

### DIFF
--- a/docs/install-shared-hosting.md
+++ b/docs/install-shared-hosting.md
@@ -1,15 +1,17 @@
 # Installing on Shared Hosting (cPanel)
 
+> Before starting, review the [installation prerequisites](installation.md) for PHP requirements and environment setup.
+
 1. **Upload files**
    - Upload the application archive to your hosting account and extract it inside the desired directory.
    - Set the `public` directory as the document root for your domain or subdomain.
 2. **Configure PHP**
-   - Ensure PHP 8.2 or higher and required extensions (OpenSSL, PDO, Mbstring, Tokenizer, Fileinfo, JSON, cURL, Zip).
+   - Ensure your account uses PHP 8.2+ with the extensions listed in the [prerequisites](installation.md).
 3. **Create database**
    - From cPanel, create a MySQL database and user, then assign privileges.
    - _Screenshot: database creation (placeholder)_
-4. **Set environment values**
-   - Copy `.env.example` to `.env` and update database credentials, `APP_URL`, mail settings, and storage driver.
+4. **Environment configuration**
+   - Complete the `.env` setup as described in the [installation prerequisites](installation.md).
    - _Screenshot: editing environment variables (placeholder)_
 5. **Run installer**
    - Visit your domain and follow the three step installer wizard to generate the app key and run migrations.
@@ -19,7 +21,6 @@
    - _Screenshot: cron job setup (placeholder)_
 7. **Create storage link**
    - Run `php artisan storage:link` or ask hosting support to create the symlink from `public/storage` to `storage/app/public`.
-
 8. **Set permissions**
    - Ensure `storage/` and `bootstrap/cache/` are writable:
      ```bash

--- a/docs/install-vps.md
+++ b/docs/install-vps.md
@@ -1,11 +1,13 @@
 # Installing on a VPS
 
+> Before starting, review the [installation prerequisites](installation.md) for PHP requirements and environment setup.
+
 1. **Server requirements**
-   - Ubuntu 22.04+, Docker (optional), Git, and PHP 8.2 with common extensions.
+   - Ubuntu 22.04+, Docker (optional), Git, and PHP. Ensure PHP version and extensions meet the [prerequisites](installation.md).
 2. **Clone repository**
    - `git clone <repo> && cd <repo>`
 3. **Environment configuration**
-   - Copy `.env.example` to `.env` and configure database, cache, queue (Redis), mail and `APP_URL`.
+   - Set up your `.env` file as described in the [installation prerequisites](installation.md).
 4. **Dependencies**
    - Run `composer install --optimize-autoloader` and `npm install && npm run build` if serving assets.
 5. **Database migration**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,22 +1,10 @@
-# Installation Guide
+# Installation
 
-1. **Clone the repository**
-   - `git clone <repo> && cd <repo>`
-2. **Install dependencies**
-   - `composer install --optimize-autoloader`
-   - `npm install && npm run build` (or `npm run dev` during development)
-3. **Environment setup**
-   - Copy `.env.example` to `.env` and update database, cache, mail, and `APP_URL` settings.
-   - Run `php artisan key:generate` to set the application key.
-4. **Database migration**
-   - Run `php artisan migrate` to create the database tables.
-5. **Interactive installer**
-   - Execute `php artisan aiassisten:install` and follow the prompts to create the first tenant, admin user, and license information.
-6. **Queue worker**
-   - Start a worker with `php artisan queue:work` or use Supervisor/systemd. See [queues.md](queues.md) for detailed instructions.
-7. **Billing configuration**
-   - Configure Stripe or PayPal credentials in `.env` and set up webhooks. See [billing.md](billing.md) for more information.
-8. **Serve the application**
-   - `php artisan serve` (or configure Nginx/Apache pointing to `public/`).
+Before installing **aiassisten**, make sure you've completed the [prerequisites](prerequisites.md).
 
-The application should now be accessible on the configured domain.
+## Choose your environment
+
+- [Installing on a VPS](install-vps.md)
+- [Installing on Shared Hosting](install-shared-hosting.md)
+
+Each guide covers environment-specific steps. After completing the appropriate guide, you can explore additional topics like [queues](queues.md) and [billing](billing.md).

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -1,0 +1,26 @@
+# Installation Prerequisites
+
+## PHP Requirements
+
+Ensure your server runs **PHP 8.2 or higher** with the following extensions enabled:
+
+- OpenSSL
+- PDO
+- Mbstring
+- Tokenizer
+- Fileinfo
+- JSON
+- cURL
+- Zip
+
+## Environment Setup
+
+1. Copy `.env.example` to `.env`.
+2. Update database, cache, mail, `APP_URL`, and other necessary settings in the `.env` file.
+3. Generate the application key:
+
+   ```bash
+   php artisan key:generate
+   ```
+
+   The browser installer will handle this automatically if you're using it.


### PR DESCRIPTION
## Summary
- add shared installation prerequisites
- convert installation.md into index linking to environment-specific guides
- reference prerequisites from VPS and shared hosting guides

## Testing
- `vendor/bin/phpunit` *(fails: Vite manifest not found; Tests: 47, Assertions: 77, Errors: 2, Failures: 16, Warnings: 2)*

------
https://chatgpt.com/codex/tasks/task_e_689b77ed10308328a5b870a038d8c987