### PR TITLE
Add AuthServiceProvider and admin gate

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Gate;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The model to policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        //
+    ];
+
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        $this->registerPolicies();
+
+        Gate::define('admin', fn ($user) => $user->isTenantAdmin() || $user->isSuperAdmin());
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
- add AuthServiceProvider defining `admin` gate for tenant and super admins
- register AuthServiceProvider so gate is available

## Testing
- `./vendor/bin/phpunit` *(fails: Vite manifest not found; multiple 404s)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ee0b97c832880b749729ec0eb0b