### PR TITLE
Add subscription editing in admin dashboard

### DIFF
--- a/app/Http/Controllers/Admin/SubscriptionController.php
+++ b/app/Http/Controllers/Admin/SubscriptionController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Plan;
 use App\Models\Subscription;
+use Illuminate\Http\Request;
 
 class SubscriptionController extends Controller
 {
@@ -11,5 +13,23 @@ class SubscriptionController extends Controller
     {
         $subscriptions = Subscription::with(['tenant','plan'])->paginate();
         return view('admin.subscriptions.index', compact('subscriptions'));
+    }
+
+    public function edit(Subscription $subscription)
+    {
+        $plans = Plan::pluck('code', 'id');
+        return view('admin.subscriptions.edit', compact('subscription', 'plans'));
+    }
+
+    public function update(Request $request, Subscription $subscription)
+    {
+        $data = $request->validate([
+            'plan_id' => 'nullable|exists:plans,id',
+            'status' => 'required|string',
+        ]);
+
+        $subscription->update($data);
+
+        return redirect()->route('admin.subscriptions.index')->with('status', 'Subscription updated');
     }
 }

--- a/resources/views/admin/subscriptions/edit.blade.php
+++ b/resources/views/admin/subscriptions/edit.blade.php
@@ -1,0 +1,38 @@
+@extends('layouts.app')
+
+@section('header')
+<h2 class="font-semibold text-xl text-gray-800 leading-tight">Edit Subscription</h2>
+@endsection
+
+@section('content')
+<div class="py-12">
+  <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+    <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+      @if(session('status'))
+        <div class="mb-4 p-3 rounded bg-emerald-100 text-emerald-800">{{ session('status') }}</div>
+      @endif
+      @if($errors->any())
+        <div class="mb-4 p-3 rounded bg-rose-100 text-rose-800">{{ $errors->first() }}</div>
+      @endif
+      <form method="POST" action="{{ route('admin.subscriptions.update', $subscription) }}" class="space-y-4">
+        @csrf
+        @method('PUT')
+        <div class="grid gap-4">
+          <select name="plan_id" class="border rounded px-3 py-2">
+            <option value="">-- Select Plan --</option>
+            @foreach($plans as $id => $code)
+              <option value="{{ $id }}" @selected(old('plan_id', $subscription->plan_id) == $id)>{{ $code }}</option>
+            @endforeach
+          </select>
+          <input type="text" name="status" value="{{ old('status', $subscription->status) }}" class="border rounded px-3 py-2" placeholder="Status" required>
+        </div>
+        <div class="mt-6 flex justify-end gap-2">
+          <a href="{{ route('admin.subscriptions.index') }}" class="px-4 py-2 border rounded">Cancel</a>
+          <button class="px-4 py-2 rounded bg-indigo-600 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+@endsection
+

--- a/resources/views/admin/subscriptions/index.blade.php
+++ b/resources/views/admin/subscriptions/index.blade.php
@@ -13,7 +13,8 @@
           <tr>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tenant</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Plan</th>
-            <th class="px-6 py-3">Status</th>
+            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
+            <th class="px-6 py-3"></th>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
@@ -22,6 +23,7 @@
             <td class="px-6 py-4 whitespace-nowrap">{{ optional($sub->tenant)->name }}</td>
             <td class="px-6 py-4 whitespace-nowrap">{{ optional($sub->plan)->code }}</td>
             <td class="px-6 py-4 whitespace-nowrap">{{ $sub->status }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-right"><a href="{{ route('admin.subscriptions.edit', $sub) }}" class="text-indigo-600 hover:underline">Edit</a></td>
           </tr>
           @endforeach
         </tbody>


### PR DESCRIPTION
## Summary
- allow admins to edit subscription plan and status
- add subscription edit blade and link from index

## Testing
- `composer install --no-progress`
- `./vendor/bin/phpunit` *(fails: Vite manifest not found and several 404s)*

------
https://chatgpt.com/codex/tasks/task_e_689b7f92ba608328a6b2a9cf8a22106c