### PR TITLE
feat(admin): allow editing user role and tenant

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Tenant;
 use App\Models\User;
 
 class UserController extends Controller
@@ -11,5 +13,24 @@ class UserController extends Controller
     {
         $users = User::with('tenant')->paginate();
         return view('admin.users.index', compact('users'));
+    }
+
+    public function edit(User $user)
+    {
+        $tenants = Tenant::orderBy('name')->get();
+        $roles = ['admin', 'user'];
+        return view('admin.users.edit', compact('user', 'tenants', 'roles'));
+    }
+
+    public function update(Request $r, User $user)
+    {
+        $data = $r->validate([
+            'role' => 'required|in:admin,user',
+            'tenant_id' => 'nullable|exists:tenants,id',
+        ]);
+
+        $user->update($data);
+
+        return redirect()->route('admin.users.index');
     }
 }

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+
+@section('header')
+<h2 class="font-semibold text-xl text-gray-800 leading-tight">Edit User</h2>
+@endsection
+
+@section('content')
+<div class="py-6">
+  <div class="max-w-3xl mx-auto sm:px-6 lg:px-8">
+    <div class="bg-white p-6 shadow-sm rounded-lg">
+      <form method="POST" action="{{ route('admin.users.update', $user) }}">
+        @csrf
+        @method('PUT')
+        <div class="grid gap-4">
+          <div>
+            <label class="block mb-1">Role</label>
+            <select name="role" class="border rounded px-3 py-2">
+              @foreach($roles as $role)
+              <option value="{{ $role }}" @selected(old('role', $user->role) == $role)>{{ ucfirst($role) }}</option>
+              @endforeach
+            </select>
+          </div>
+          <div>
+            <label class="block mb-1">Tenant</label>
+            <select name="tenant_id" class="border rounded px-3 py-2">
+              <option value="">-</option>
+              @foreach($tenants as $tenant)
+              <option value="{{ $tenant->id }}" @selected(old('tenant_id', $user->tenant_id) == $tenant->id)>{{ $tenant->name }}</option>
+              @endforeach
+            </select>
+          </div>
+        </div>
+        <div class="mt-6 flex justify-end gap-2">
+          <a href="{{ route('admin.users.index') }}" class="px-4 py-2 border rounded">Cancel</a>
+          <button class="px-4 py-2 rounded bg-indigo-600 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -15,6 +15,7 @@
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tenant</th>
             <th class="px-6 py-3">Role</th>
+            <th class="px-6 py-3"></th>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
@@ -24,6 +25,9 @@
             <td class="px-6 py-4 whitespace-nowrap">{{ $user->email }}</td>
             <td class="px-6 py-4 whitespace-nowrap">{{ optional($user->tenant)->name ?? '-' }}</td>
             <td class="px-6 py-4 whitespace-nowrap">{{ $user->role }}</td>
+            <td class="px-6 py-4 whitespace-nowrap text-right">
+              <a href="{{ route('admin.users.edit', $user) }}" class="text-indigo-600 hover:text-indigo-900">Edit</a>
+            </td>
           </tr>
           @endforeach
         </tbody>


### PR DESCRIPTION
## Summary
- enable admins to edit user roles and tenant assignments
- add dedicated view for editing users
- link to edit page from admin user list

## Testing
- `vendor/bin/phpunit` *(fails: Vite manifest not found; multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689b7f91892c8328b0207ae178129f65