### PR TITLE
chore: guard chat view vite build

### DIFF
--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -27,5 +27,7 @@
 @endsection
 
 @push('scripts')
-  @vite('resources/js/chat.js')
+  @if (file_exists(public_path('build/manifest.json')))
+    @vite('resources/js/chat.js')
+  @endif
 @endpush


### PR DESCRIPTION
## Summary
- avoid calling `@vite` in chat page when no Vite manifest is present

## Testing
- `npm run build`
- `./vendor/bin/phpunit` *(fails: `Tests\Feature\UploadTest::test_pdf_upload_is_stored_and_returns_url` expected 200 got 404)*


------
https://chatgpt.com/codex/tasks/task_e_68a5fddbfd6c8328b1c8223fd2a9c921