### PR TITLE
Guard chat routes and handle unauthenticated access

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -63,13 +63,6 @@ Route::middleware(['auth'])->group(function () {
     Route::post('/billing/subscribe', [BillingController::class, 'subscribe'])->name('billing.subscribe');
     Route::get('/billing/invoice/{invoice}', [BillingController::class, 'invoice'])->name('billing.invoice');
 
-// Chatbot: tidak dikunci lisensi/plan/kuota
-Route::middleware(['throttle:tasks'])->group(function () {
-    Route::get('/chat', [ChatController::class, 'index'])->name('chat');
-    Route::post('/chat', [ChatController::class, 'send'])->name('chat.send');
-});
-
-
     // Logout
     Route::post('/logout', function (Request $request) {
         Auth::guard('web')->logout();
@@ -77,6 +70,12 @@ Route::middleware(['throttle:tasks'])->group(function () {
         $request->session()->regenerateToken();
         return redirect('/');
     })->name('logout');
+});
+
+// Chatbot: tidak dikunci lisensi/plan/kuota
+Route::middleware(['auth', 'throttle:tasks'])->group(function () {
+    Route::get('/chat', [ChatController::class, 'index'])->name('chat');
+    Route::post('/chat', [ChatController::class, 'send'])->name('chat.send');
 });
 
 // Webhooks


### PR DESCRIPTION
## Summary
- Protect chat routes with auth middleware
- Validate authenticated user in ChatController and return messages or JSON for guests

## Testing
- `php artisan test` *(fails: 18 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ff2dcecc8328a6c7acf7274effd9